### PR TITLE
Adds two minor changes

### DIFF
--- a/boulder_profile.links.menu.yml
+++ b/boulder_profile.links.menu.yml
@@ -2,3 +2,4 @@ boulder_profile.front_page:
   title: 'Home'
   route_name: '<front>'
   menu_name: main
+  weight: -999

--- a/config/install/field.field.media.image.field_media_image.yml
+++ b/config/install/field.field.media.image.field_media_image.yml
@@ -21,7 +21,7 @@ settings:
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
-  max_filesize: '2 MB'
+  max_filesize: '24 MB'
   max_resolution: ''
   min_resolution: ''
   alt_field: true


### PR DESCRIPTION
- Decreases the weight of the home link in the main menu to a very small number (`-999`) to ensure it always appears first on the left. Resolves CuBoulder/tiamat-theme#351
- Increases the maximum image upload size from `2 MB` to `24 MB`. Resolves CuBoulder/tiamat-theme#353

Sister PR in: [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/46)