### PR TITLE
Adds Map plugin for embedding Campus Maps

### DIFF
--- a/config/install/editor.editor.full_html.yml
+++ b/config/install/editor.editor.full_html.yml
@@ -31,6 +31,7 @@ settings:
       - code
       - '|'
       - 'box'
+      - 'map'
       - 'tooltip'
       - 'invisible'
   plugins:

--- a/config/install/editor.editor.wysiwyg.yml
+++ b/config/install/editor.editor.wysiwyg.yml
@@ -39,6 +39,7 @@ settings:
       - removeFormat
       - '|'
       - 'box'
+      - 'map'
       - 'tooltip'
       - 'invisible'
   plugins:

--- a/config/install/filter.format.full_html.yml
+++ b/config/install/filter.format.full_html.yml
@@ -106,3 +106,9 @@ filters:
     status: false
     weight: -42
     settings: {  }
+  filter_map_embed:
+    id: filter_map_embed
+    provider: ucb_ckeditor_plugins
+    status: true
+    weight: 10
+    settings: {  }

--- a/config/install/filter.format.wysiwyg.yml
+++ b/config/install/filter.format.wysiwyg.yml
@@ -36,7 +36,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right text-align-justify"> <h2 class="text-align-left text-align-center text-align-right text-align-justify"> <h3 class="text-align-left text-align-center text-align-right text-align-justify"> <h4 class="text-align-left text-align-center text-align-right text-align-justify"> <h5 class="text-align-left text-align-center text-align-right text-align-justify"> <h6 class="text-align-left text-align-center text-align-right text-align-justify"> <strong> <em> <sub> <sup> <blockquote> <a href> <ul> <ol reversed start> <li> <hr> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-align> <abbr title class="ucb-tooltip"> <span class="sr-only ucb-invisible"> <div class="ucb-box ucb-box-inner ucb-box-title ucb-box-content ucb-box-title-left ucb-box-title-center ucb-box-title-right ucb-box-title-hidden ucb-box-alignment-left ucb-box-alignment-none ucb-box-alignment-right ucb-box-style-fill ucb-box-style-outline ucb-box-style-none ucb-box-theme-black ucb-box-theme-darkgray ucb-box-theme-lightgray ucb-box-theme-white">'      
+      allowed_html: '<br> <p class="text-align-left text-align-center text-align-right text-align-justify"> <h2 class="text-align-left text-align-center text-align-right text-align-justify"> <h3 class="text-align-left text-align-center text-align-right text-align-justify"> <h4 class="text-align-left text-align-center text-align-right text-align-justify"> <h5 class="text-align-left text-align-center text-align-right text-align-justify"> <h6 class="text-align-left text-align-center text-align-right text-align-justify"> <strong> <em> <sub> <sup> <blockquote> <a href> <ul> <ol reversed start> <li> <hr> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-align> <abbr title class="ucb-tooltip"> <span class="sr-only ucb-invisible"> <div class="ucb-box ucb-box-inner ucb-box-title ucb-box-content ucb-box-title-left ucb-box-title-center ucb-box-title-right ucb-box-title-hidden ucb-box-alignment-left ucb-box-alignment-none ucb-box-alignment-right ucb-box-style-fill ucb-box-style-outline ucb-box-style-none ucb-box-theme-black ucb-box-theme-darkgray ucb-box-theme-lightgray ucb-box-theme-white"> <ucb-map class="ucb-map ucb-campus-map ucb-map-size-small ucb-map-size-medium ucb-map-size-large" data-map-location>'      
       filter_html_help: true
       filter_html_nofollow: true
   filter_url:
@@ -110,4 +110,10 @@ filters:
     provider: filter
     status: true
     weight: -44
+    settings: {  }
+  filter_map_embed:
+    id: filter_map_embed
+    provider: ucb_ckeditor_plugins
+    status: true
+    weight: 10
     settings: {  }


### PR DESCRIPTION
This update adds the Map plugin to CKEditor, which allows a content editor to provide a link shared from the [CU Boulder Campus Map](https://www.colorado.edu/map/) and embeds a map widget on a page. Just as in the [CKEditor 4 Shortcode](https://websupport.colorado.edu/article/425-campus-map-shortcode) there are three size options to choose from for the widget. The Map plugin outputs web component-like syntax for easier migration and future changes (see `README.md` for the schemas). CuBoulder/ucb_ckeditor_plugins#13

CuBoulder/tiamat-theme#258

Sister PR in: [ucb_ckeditor_plugins](https://github.com/CuBoulder/ucb_ckeditor_plugins/pull/15), [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/48)