### PR TITLE
Removes "D9" from theme name and the theme, custom entities Composer package names

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -88,5 +88,5 @@ dependencies:
 # List any themes that should be installed as part of the profile installation.
 # Note that this will not set any theme as the default theme.
 themes:
-  - boulderD9_base
+  - boulder_base
   - gin

--- a/config/install/block.block.boulder_base_breadcrumbs.yml
+++ b/config/install/block.block.boulder_base_breadcrumbs.yml
@@ -4,9 +4,9 @@ dependencies:
   module:
     - system
   theme:
-    - boulderD9_base
-id: boulderD9_base_breadcrumbs
-theme: boulderD9_base
+    - boulder_base
+id: boulder_base_breadcrumbs
+theme: boulder_base
 region: breadcrumb
 weight: 0
 provider: null

--- a/config/install/block.block.boulder_base_content.yml
+++ b/config/install/block.block.boulder_base_content.yml
@@ -4,9 +4,9 @@ dependencies:
   module:
     - system
   theme:
-    - boulderD9_base
-id: boulderD9_base_content
-theme: boulderD9_base
+    - boulder_base
+id: boulder_base_content
+theme: boulder_base
 region: content
 weight: 0
 provider: null

--- a/config/install/block.block.boulder_base_footer_menu.yml
+++ b/config/install/block.block.boulder_base_footer_menu.yml
@@ -6,9 +6,9 @@ dependencies:
   module:
     - system
   theme:
-    - boulderD9_base
-id: boulderD9_base_footer_menu
-theme: boulderD9_base
+    - boulder_base
+id: boulder_base_footer_menu
+theme: boulder_base
 region: footer_menu
 weight: 0
 provider: null

--- a/config/install/block.block.boulder_base_help.yml
+++ b/config/install/block.block.boulder_base_help.yml
@@ -4,9 +4,9 @@ dependencies:
   module:
     - help
   theme:
-    - boulderD9_base
-id: boulderD9_base_help
-theme: boulderD9_base
+    - boulder_base
+id: boulder_base_help
+theme: boulder_base
 region: content
 weight: -30
 provider: null

--- a/config/install/block.block.boulder_base_local_actions.yml
+++ b/config/install/block.block.boulder_base_local_actions.yml
@@ -2,9 +2,9 @@ langcode: en
 status: true
 dependencies:
   theme:
-    - boulderD9_base
-id: boulderD9_base_local_actions
-theme: boulderD9_base
+    - boulder_base
+id: boulder_base_local_actions
+theme: boulder_base
 region: content
 weight: -20
 provider: null

--- a/config/install/block.block.boulder_base_main_menu.yml
+++ b/config/install/block.block.boulder_base_main_menu.yml
@@ -6,9 +6,9 @@ dependencies:
   module:
     - system
   theme:
-    - boulderD9_base
-id: boulderD9_base_main_menu
-theme: boulderD9_base
+    - boulder_base
+id: boulder_base_main_menu
+theme: boulder_base
 region: primary_menu
 weight: 0
 provider: null

--- a/config/install/block.block.boulder_base_messages.yml
+++ b/config/install/block.block.boulder_base_messages.yml
@@ -4,9 +4,9 @@ dependencies:
   module:
     - system
   theme:
-    - boulderD9_base
-id: boulderD9_base_messages
-theme: boulderD9_base
+    - boulder_base
+id: boulder_base_messages
+theme: boulder_base
 region: above_content
 weight: -3
 provider: null

--- a/config/install/block.block.boulder_base_secondary_menu.yml
+++ b/config/install/block.block.boulder_base_secondary_menu.yml
@@ -6,9 +6,9 @@ dependencies:
   module:
     - system
   theme:
-    - boulderD9_base
-id: boulderD9_base_secondary_menu
-theme: boulderD9_base
+    - boulder_base
+id: boulder_base_secondary_menu
+theme: boulder_base
 region: secondary_menu
 weight: 0
 provider: null

--- a/config/install/block.block.site_contact_info_footer.yml
+++ b/config/install/block.block.site_contact_info_footer.yml
@@ -4,9 +4,9 @@ dependencies:
   module:
     - ucb_site_configuration
   theme:
-    - boulderD9_base
+    - boulder_base
 id: site_contact_info_footer
-theme: boulderD9_base
+theme: boulder_base
 region: footer
 weight: 0
 provider: null

--- a/config/install/block.block.social_media_links.yml
+++ b/config/install/block.block.social_media_links.yml
@@ -7,9 +7,9 @@ dependencies:
   module:
     - system
   theme:
-    - boulderD9_base
+    - boulder_base
 id: social_media_links
-theme: boulderD9_base
+theme: boulder_base
 region: social
 weight: 0
 provider: null

--- a/config/install/system.theme.yml
+++ b/config/install/system.theme.yml
@@ -1,4 +1,4 @@
 _core:
   default_config_hash: 6lQ55NXM9ysybMQ6NzJj4dtiQ1dAkOYxdDompa-r_kk
 admin: gin
-default: boulderD9_base
+default: boulder_base


### PR DESCRIPTION
CuBoulder/tiamat-theme#435

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/452), [tiamat-custom-entities](https://github.com/CuBoulder/tiamat-custom-entities/pull/70), [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/52), [tiamat-project-template](https://github.com/CuBoulder/tiamat-project-template/pull/28), [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/8), [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/26)