### PR TITLE
Remove full justification setting for wysiwyg

### DIFF
--- a/config/install/editor.editor.wysiwyg.yml
+++ b/config/install/editor.editor.wysiwyg.yml
@@ -59,7 +59,6 @@ settings:
         - left
         - center
         - right
-        - justify
     media_media:
       allow_view_mode_override: true
 image_upload:


### PR DESCRIPTION
Removing the full justification setting option for they WYSIWYG text authoring configuration.  