### PR TITLE
Adds Person Title Module, Hook Event Dispatcher

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -76,6 +76,7 @@ install:
   - ucb_site_configuration
   - ucb_campus_news
   - ucb_user_invite
+  - ucb_person_title
   - ucb_focal_image_enable
   - ucb_bootstrap_layouts
   - media_library_form_element
@@ -83,8 +84,7 @@ install:
   - ucb_migration_shortcodes
   - ucb_third_party_libraries
   - ucb_default_content
-  - hook_event_dispatcher
-  
+
 # Required modules
 # Note that any dependencies of the modules listed here will be installed automatically.
 dependencies:

--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -69,6 +69,8 @@ install:
   - redirect
   - devel
   - devel_generate
+  - hook_event_dispatcher
+  - core_event_dispatcher
   - cu_boulder_content_types
   - ucb_admin_menus
   - ucb_site_configuration
@@ -81,6 +83,7 @@ install:
   - ucb_migration_shortcodes
   - ucb_third_party_libraries
   - ucb_default_content
+  - hook_event_dispatcher
   
 # Required modules
 # Note that any dependencies of the modules listed here will be installed automatically.


### PR DESCRIPTION
Some hooks in custom modules break focal point functionality due to a bug in Core. With this change, the focal point preview on Person pages still works while allowing additional functionality needed via custom modules such as hiding the title and allowing the title to be created using a Person's First and Last Name fields. 

Includes:

- `tiamat10-project-template` => https://github.com/CuBoulder/tiamat10-project-template/pull/14
-  `tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/27
- `ucb_person_title` => https://github.com/CuBoulder/ucb_person_title/pull/3

Resolves https://github.com/CuBoulder/ucb_person_title/issues/2, Resolves https://github.com/CuBoulder/tiamat-theme/issues/220