### PR TITLE
Fixes UCB Person Page custom modules

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -81,6 +81,8 @@ install:
   - ucb_migration_shortcodes
   - ucb_third_party_libraries
   - ucb_default_content
+  - ucb_person_title
+  - ucb_article_author
   
 # Required modules
 # Note that any dependencies of the modules listed here will be installed automatically.


### PR DESCRIPTION
Adds the fixed versions of `UCB Person Title` and `UCB Article Author` to template and profile. Allows First and Last Name fields to create a Person Page title, getting rid of the need to enter a title for these pages. Also automatically creates a Byline taxonomy for newly created Person Pages, for use in the Byline field. 

Includes:

- `tiamat10-project-template` => https://github.com/CuBoulder/tiamat10-project-template/pull/15 (`issue/ucb_person_title/2`)
-  `tiamat-profile` => `issue/ucb_person_title/2`
-  `ucb_person_title` => https://github.com/CuBoulder/ucb_person_title/pull/4 (`issue/2`)
-  `ucb_article_author` => https://github.com/CuBoulder/ucb_article_author/pull/2 (`issue/1`)

Resolves https://github.com/CuBoulder/ucb_article_author/issues/1, Resolves https://github.com/CuBoulder/ucb_person_title/issues/2