### PR TITLE
Sets site default email address in the profile

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -1,6 +1,6 @@
 name: CU Boulder Install Profile
 type: profile
-description: "CU Boulder Web Express D9 Installation Profile"
+description: "CU Boulder Web Express D10 Installation Profile"
 core_version_requirement: "^10"
 # Modules to install to support the profile.
 install:

--- a/boulder_profile.install
+++ b/boulder_profile.install
@@ -19,6 +19,9 @@ function boulder_profile_install() {
   include_once DRUPAL_ROOT . '/core/profiles/standard/standard.install';
   standard_install();
 
+  // Sets the site mail.
+  \Drupal::configFactory()->getEditable('system.site')->set('mail', 'webexpress_noreply@colorado.edu');
+
   /**
    * Create inital users for the Web Team
    */


### PR DESCRIPTION
This update:
- Sets the site default email address in the profile at install time. CuBoulder/tiamat-theme#500
- Changes "D9" to "D10" in the Drupal module description.