### PR TITLE
Adds home page setting to CU Boulder site settings

### DIFF
--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -208,6 +208,7 @@ permissions:
   - 'edit ucb site appearance'
   - 'edit ucb site contact info'
   - 'edit ucb site general'
+  - 'edit ucb site pages'
   - 'invite users'
   - 'link to any page'
   - 'revert all revisions'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -296,6 +296,7 @@ permissions:
   - 'edit ucb site appearance'
   - 'edit ucb site contact info'
   - 'edit ucb site general'
+  - 'edit ucb site pages'
   - 'edit webform assets'
   - 'edit webform source'
   - 'edit webform twig'

--- a/config/install/user.role.site_manager.yml
+++ b/config/install/user.role.site_manager.yml
@@ -165,6 +165,7 @@ permissions:
   - 'edit terms in ucb_person_job_type'
   - 'edit ucb site appearance'
   - 'edit ucb site contact info'
+  - 'edit ucb site pages'
   - 'invite users'
   - 'link to any page'
   - 'revert all revisions'


### PR DESCRIPTION
This update to CU Boulder Site Configuration:
- Adds a new home page setting to CU Boulder site settings. CuBoulder/tiamat-theme#506
- Adds a new `edit ucb site pages` permission:
  - Architect, Developer, and Site Manager have been given this new permission. 
  - While "Pages" could eventually be split off into its own tab, the settings are found under "General", at least for now. The existing settings in "General" still require `edit ucb site general` to access.
- Cleans up PHP files in CU Boulder Site Configuration according to Drupal coding standards. Full compliance has not yet been achieved. CuBoulder/ucb_site_configuration#27

Sister PR in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/28)