### PR TITLE
Completes in-content menu blocks

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -81,6 +81,7 @@ install:
   - media_alias_display
   - media_entity_file_replace
   - media_file_delete
+  - menu_block
   - shortcode
   - ucb_migration_shortcodes
   - ucb_third_party_libraries


### PR DESCRIPTION
This update completes in-content menu blocks (menu blocks placed outside of a navigation bar, e.g. in a sidebar) by styling them and adding the [Menu Block](https://www.drupal.org/project/menu_block) contrib module for additional options.

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/552), [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/25), [ucb_admin_menus](https://github.com/CuBoulder/ucb_admin_menus/pull/13)

CuBoulder/tiamat-theme#267
CuBoulder/tiamat-theme#528