### PR TITLE
CU Boulder Site Configuration 2.5.2

### DIFF
--- a/config/install/user.role.site_manager.yml
+++ b/config/install/user.role.site_manager.yml
@@ -165,6 +165,7 @@ permissions:
   - 'edit terms in ucb_person_job_type'
   - 'edit ucb site appearance'
   - 'edit ucb site contact info'
+  - 'edit ucb site general'
   - 'edit ucb site pages'
   - 'invite users'
   - 'link to any page'


### PR DESCRIPTION
This update:
- Places "Type" and "Affiliation" under  an "Advanced" section in the "General" settings. This section behaves identically to the one in "Appearance and layout", requiring the same special permission to access.
- Gives the "Site Manager" role the `edit ucb site general` permission to access the "General" settings.

Sister PR in: [ucb_site_configuration](https://github.com/CuBoulder/ucb_site_configuration/pull/34)
CuBoulder/ucb_site_configuration#33