### PR TITLE
Remove 'Categories' taxonomy term + Associated Permissions

### DIFF
--- a/config/install/taxonomy.vocabulary.categories.yml
+++ b/config/install/taxonomy.vocabulary.categories.yml
@@ -1,7 +1,0 @@
-langcode: en
-status: true
-dependencies: {  }
-name: Categories
-vid: categories
-description: ''
-weight: 0

--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -40,7 +40,6 @@ dependencies:
     - node.type.ucb_people_list_page
     - node.type.ucb_person
     - taxonomy.vocabulary.byline
-    - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.category
     - taxonomy.vocabulary.department
     - taxonomy.vocabulary.filter_1
@@ -130,7 +129,6 @@ permissions:
   - 'create newsletter content'
   - 'create slider block content'
   - 'create terms in byline'
-  - 'create terms in categories'
   - 'create terms in category'
   - 'create terms in department'
   - 'create terms in filter_1'
@@ -244,7 +242,6 @@ permissions:
   - 'delete own webform'
   - 'delete own webform submission'
   - 'delete terms in byline'
-  - 'delete terms in categories'
   - 'delete terms in category'
   - 'delete terms in department'
   - 'delete terms in filter_1'
@@ -311,7 +308,6 @@ permissions:
   - 'edit own webform'
   - 'edit own webform submission'
   - 'edit terms in byline'
-  - 'edit terms in categories'
   - 'edit terms in category'
   - 'edit terms in department'
   - 'edit terms in filter_1'

--- a/config/install/user.role.content_editor.yml
+++ b/config/install/user.role.content_editor.yml
@@ -39,7 +39,6 @@ dependencies:
     - node.type.ucb_people_list_page
     - node.type.ucb_person
     - taxonomy.vocabulary.byline
-    - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.category
     - taxonomy.vocabulary.department
     - taxonomy.vocabulary.filter_1
@@ -104,7 +103,6 @@ permissions:
   - 'create media'
   - 'create slider block content'
   - 'create terms in byline'
-  - 'create terms in categories'
   - 'create terms in category'
   - 'create terms in department'
   - 'create terms in filter_1'
@@ -210,7 +208,6 @@ permissions:
   - 'delete own ucb_person content'
   - 'delete own video media'
   - 'delete terms in byline'
-  - 'delete terms in categories'
   - 'delete terms in category'
   - 'delete terms in department'
   - 'delete terms in filter_1'
@@ -272,7 +269,6 @@ permissions:
   - 'edit own ucb_person content'
   - 'edit own video media'
   - 'edit terms in byline'
-  - 'edit terms in categories'
   - 'edit terms in category'
   - 'edit terms in department'
   - 'edit terms in filter_1'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -43,7 +43,6 @@ dependencies:
     - node.type.ucb_people_list_page
     - node.type.ucb_person
     - taxonomy.vocabulary.byline
-    - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.category
     - taxonomy.vocabulary.department
     - taxonomy.vocabulary.filter_1
@@ -218,7 +217,6 @@ permissions:
   - 'create slider block content'
   - 'create statuspage_block block content'
   - 'create terms in byline'
-  - 'create terms in categories'
   - 'create terms in category'
   - 'create terms in department'
   - 'create terms in filter_1'
@@ -339,7 +337,6 @@ permissions:
   - 'delete own webform'
   - 'delete own webform submission'
   - 'delete terms in byline'
-  - 'delete terms in categories'
   - 'delete terms in category'
   - 'delete terms in department'
   - 'delete terms in filter_1'
@@ -411,7 +408,6 @@ permissions:
   - 'edit own webform'
   - 'edit own webform submission'
   - 'edit terms in byline'
-  - 'edit terms in categories'
   - 'edit terms in category'
   - 'edit terms in department'
   - 'edit terms in filter_1'

--- a/config/install/user.role.site_manager.yml
+++ b/config/install/user.role.site_manager.yml
@@ -39,7 +39,6 @@ dependencies:
     - node.type.ucb_people_list_page
     - node.type.ucb_person
     - taxonomy.vocabulary.byline
-    - taxonomy.vocabulary.categories
     - taxonomy.vocabulary.category
     - taxonomy.vocabulary.department
     - taxonomy.vocabulary.filter_1
@@ -114,7 +113,6 @@ permissions:
   - 'create media'
   - 'create slider block content'
   - 'create terms in byline'
-  - 'create terms in categories'
   - 'create terms in category'
   - 'create terms in department'
   - 'create terms in filter_1'
@@ -220,7 +218,6 @@ permissions:
   - 'delete own ucb_person content'
   - 'delete own video media'
   - 'delete terms in byline'
-  - 'delete terms in categories'
   - 'delete terms in category'
   - 'delete terms in department'
   - 'delete terms in filter_1'
@@ -282,7 +279,6 @@ permissions:
   - 'edit own ucb_person content'
   - 'edit own video media'
   - 'edit terms in byline'
-  - 'edit terms in categories'
   - 'edit terms in category'
   - 'edit terms in department'
   - 'edit terms in filter_1'


### PR DESCRIPTION
Removing the **_'Categories'_** taxonomy term and permissions associated with it, as all current Content Types and Blocks use the correct taxonomy term **'Category'** for terms and sorting/filtering. There were no references to the deleted **_'Categories'_** term in `ucb_custom_entities` or any other custom modules, such as `Campus News` or `Site Configuration`, only fields with a machine name that included the word 'categories", but this was only in reference to a collection of **'Category'** terms and not the actual _**'Categories'**_ term.
 
Resolves https://github.com/CuBoulder/tiamat-theme/issues/587