### PR TITLE
Switching to Express Admin for the administration theme

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -102,3 +102,4 @@ dependencies:
 # Note that this will not set any theme as the default theme.
 themes:
   - boulder_base
+  - express_admin

--- a/config/install/system.theme.yml
+++ b/config/install/system.theme.yml
@@ -1,2 +1,2 @@
-admin: claro
+admin: express_admin
 default: boulder_base


### PR DESCRIPTION
Express Admin administration sub-theme with Claro as the base theme set as the default admin theme.  