### PR TITLE
Adds "Administer Users by Role" contrib module and associated configuration

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: "^10"
 install:
   - history
   - automated_cron
+  - administerusersbyrole
   - block_content
   - breakpoint
   - config

--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -5,8 +5,8 @@ core_version_requirement: "^10"
 # Modules to install to support the profile.
 install:
   - history
-  - automated_cron
   - administerusersbyrole
+  - automated_cron
   - block_content
   - breakpoint
   - config

--- a/boulder_profile.install
+++ b/boulder_profile.install
@@ -114,7 +114,10 @@ function _boulder_profile_install_shortcuts() {
   ])->save();
 
   /**
-   * Installs administerusersbyrole settings.
+   * Installs "Administer users by role" contrib module settings.
+   *
+   * This workaround is necessary as the settings get overriden by the contrib
+   * module following the installation of the roles.
    */
   function _boulder_profile_install_administerusersbyrole_settings() {
     $profilePath = Drupal::getContainer()->get('extension.path.resolver')->getPath('profile', 'boulder_profile');

--- a/boulder_profile.install
+++ b/boulder_profile.install
@@ -7,6 +7,7 @@
 
 use Drupal\shortcut\Entity\Shortcut;
 use Drupal\user\Entity\User;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Implements hook_install().
@@ -20,11 +21,10 @@ function boulder_profile_install() {
   include_once DRUPAL_ROOT . '/core/profiles/standard/standard.install';
   standard_install();
 
-  // Sets the site mail.
-  \Drupal::configFactory()->getEditable('system.site')->set('mail', 'webexpress_noreply@colorado.edu');
-
+  // Afterward, run the custom install tasks.
   _boulder_profile_install_users();
   _boulder_profile_install_shortcuts();
+  _boulder_profile_install_administerusersbyrole_settings();
 }
 
 /**
@@ -112,4 +112,14 @@ function _boulder_profile_install_shortcuts() {
     'weight' => -17,
     'link' => ['uri' => 'internal:/admin/structure/menu/manage/main'],
   ])->save();
+
+  /**
+   * Installs administerusersbyrole settings.
+   */
+  function _boulder_profile_install_administerusersbyrole_settings() {
+    $profilePath = Drupal::getContainer()->get('extension.path.resolver')->getPath('profile', 'boulder_profile');
+    $settingsYaml = Yaml::parse(file_get_contents($profilePath . '/config/install/administerusersbyrole.settings.yml'));
+    \Drupal::configFactory()->getEditable('administerusersbyrole.settings')->set('roles', $settingsYaml['roles'])->save();
+  }
+
 }

--- a/boulder_profile.install
+++ b/boulder_profile.install
@@ -112,17 +112,16 @@ function _boulder_profile_install_shortcuts() {
     'weight' => -17,
     'link' => ['uri' => 'internal:/admin/structure/menu/manage/main'],
   ])->save();
+}
 
-  /**
-   * Installs "Administer users by role" contrib module settings.
-   *
-   * This workaround is necessary as the settings get overriden by the contrib
-   * module following the installation of the roles.
-   */
-  function _boulder_profile_install_administerusersbyrole_settings() {
-    $profilePath = Drupal::getContainer()->get('extension.path.resolver')->getPath('profile', 'boulder_profile');
-    $settingsYaml = Yaml::parse(file_get_contents($profilePath . '/config/install/administerusersbyrole.settings.yml'));
-    \Drupal::configFactory()->getEditable('administerusersbyrole.settings')->set('roles', $settingsYaml['roles'])->save();
-  }
-
+/**
+ * Installs "Administer users by role" contrib module settings.
+ *
+ * This workaround is necessary as the settings get overriden by the contrib
+ * module following the installation of the roles.
+ */
+function _boulder_profile_install_administerusersbyrole_settings() {
+  $profilePath = Drupal::getContainer()->get('extension.path.resolver')->getPath('profile', 'boulder_profile');
+  $settingsYaml = Yaml::parse(file_get_contents($profilePath . '/config/install/administerusersbyrole.settings.yml'));
+  \Drupal::configFactory()->getEditable('administerusersbyrole.settings')->set('roles', $settingsYaml['roles'])->save();
 }

--- a/config/install/administerusersbyrole.settings.yml
+++ b/config/install/administerusersbyrole.settings.yml
@@ -1,9 +1,9 @@
 roles:
   site_manager: safe
   content_editor: safe
-  layout_manager: safe
-  site_owner: safe
+  layout_manager: unsafe
+  site_owner: unsafe
   edit_own_content: safe
-  newsletter: safe
+  newsletter: unsafe
   webform_editor: safe
   webform_submissions_viewer: safe

--- a/config/install/administerusersbyrole.settings.yml
+++ b/config/install/administerusersbyrole.settings.yml
@@ -1,0 +1,9 @@
+roles:
+  site_manager: safe
+  content_editor: safe
+  layout_manager: safe
+  site_owner: safe
+  edit_own_content: safe
+  newsletter: safe
+  webform_editor: safe
+  webform_submissions_viewer: safe

--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -57,6 +57,7 @@ dependencies:
     - taxonomy.vocabulary.tags
     - taxonomy.vocabulary.ucb_person_job_type
   module:
+    - administerusersbyrole
     - aggregator
     - block
     - block_content
@@ -72,6 +73,8 @@ dependencies:
     - node
     - paragraphs
     - path
+    - redirect
+    - scheduler
     - search
     - shortcut
     - system
@@ -100,6 +103,7 @@ permissions:
   - 'access taxonomy overview'
   - 'access toolbar'
   - 'access user profiles'
+  - 'access users overview'
   - 'access webform overview'
   - 'administer blocks'
   - 'administer contact forms'
@@ -113,6 +117,7 @@ permissions:
   - 'administer user invite'
   - 'administer users'
   - 'administer webform element access'
+  - 'cancel users by role'
   - 'configure all basic_page node layout overrides'
   - 'configure any layout'
   - 'configure editable basic_page node layout overrides'
@@ -364,6 +369,7 @@ permissions:
   - 'edit ucb site contact info'
   - 'edit ucb site content types'
   - 'edit ucb site general'
+  - 'edit users by role'
   - 'invite users'
   - 'link to any page'
   - 'revert all revisions'
@@ -403,6 +409,7 @@ permissions:
   - 'revert ucb_issue_archive revisions'
   - 'revert ucb_people_list_page revisions'
   - 'revert ucb_person revisions'
+  - 'role-assign users by role'
   - 'schedule publishing of media'
   - 'schedule publishing of nodes'
   - 'schedule publishing of taxonomy_term'
@@ -462,3 +469,4 @@ permissions:
   - 'view ucb_person revisions'
   - 'view unpublished paragraphs'
   - 'view user email addresses'
+  - 'view users by role'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -60,6 +60,7 @@ dependencies:
     - taxonomy.vocabulary.tags
     - taxonomy.vocabulary.ucb_person_job_type
   module:
+    - administerusersbyrole
     - aggregator
     - antibot
     - block
@@ -81,10 +82,9 @@ dependencies:
     - image
     - layout_builder
     - layout_builder_iframe_modal
+    - linkit
     - media
     - media_file_delete
-    - layout_builder_iframe_modal
-    - linkit
     - metatag
     - node
     - paragraphs
@@ -126,6 +126,7 @@ permissions:
   - 'access toolbar'
   - 'access user contact forms'
   - 'access user profiles'
+  - 'access users overview'
   - 'access webform help'
   - 'access webform overview'
   - 'access webform submission user'
@@ -203,14 +204,16 @@ permissions:
   - 'administer webform'
   - 'administer webform element access'
   - 'administer webform submission'
+  - 'allow empty user mail'
   - 'bypass node access'
+  - 'cancel users by role'
   - 'configure all basic_page node layout overrides'
   - 'configure any layout'
   - 'configure editable basic_page node layout overrides'
+  - 'configure layout builder iframe modal'
   - 'create and edit custom blocks'
   - 'create article_list_block block content'
   - 'create audio media'
-  - 'configure layout builder iframe modal'
   - 'create basic_page content'
   - 'create collection_grid block content'
   - 'create collection_item_page content'
@@ -262,6 +265,7 @@ permissions:
   - 'create ucb_slate_form block content'
   - 'create ucb_tag_cloud block content'
   - 'create url aliases'
+  - 'create users'
   - 'create video media'
   - 'create video_hero_unit block content'
   - 'create video_reveal block content'
@@ -470,6 +474,7 @@ permissions:
   - 'edit ucb site contact info'
   - 'edit ucb site content types'
   - 'edit ucb site general'
+  - 'edit users by role'
   - 'edit webform assets'
   - 'edit webform source'
   - 'edit webform twig'
@@ -518,6 +523,7 @@ permissions:
   - 'revert ucb_issue_archive revisions'
   - 'revert ucb_people_list_page revisions'
   - 'revert ucb_person revisions'
+  - 'role-assign users by role'
   - 'schedule publishing of media'
   - 'schedule publishing of nodes'
   - 'schedule publishing of taxonomy_term'
@@ -584,3 +590,4 @@ permissions:
   - 'view ucb_person revisions'
   - 'view unpublished paragraphs'
   - 'view user email addresses'
+  - 'view users by role'

--- a/config/install/user.role.site_manager.yml
+++ b/config/install/user.role.site_manager.yml
@@ -57,6 +57,7 @@ dependencies:
     - taxonomy.vocabulary.tags
     - taxonomy.vocabulary.ucb_person_job_type
   module:
+    - administerusersbyrole
     - block_content
     - contact
     - contextual
@@ -96,6 +97,7 @@ permissions:
   - 'access taxonomy overview'
   - 'access toolbar'
   - 'access user profiles'
+  - 'access users overview'
   - 'access webform overview'
   - 'administer contact forms'
   - 'administer menu'
@@ -346,6 +348,7 @@ permissions:
   - 'edit ucb site contact info'
   - 'edit ucb site content types'
   - 'edit ucb site general'
+  - 'edit users by role'
   - 'invite users'
   - 'link to any page'
   - 'revert all revisions'
@@ -385,6 +388,7 @@ permissions:
   - 'revert ucb_issue_archive revisions'
   - 'revert ucb_people_list_page revisions'
   - 'revert ucb_person revisions'
+  - 'role-assign users by role'
   - 'schedule publishing of media'
   - 'schedule publishing of nodes'
   - 'schedule publishing of taxonomy_term'
@@ -441,3 +445,4 @@ permissions:
   - 'view ucb_person revisions'
   - 'view unpublished paragraphs'
   - 'view user email addresses'
+  - 'view users by role'


### PR DESCRIPTION
Allows Site Managers to configure users with an equal or lower permission level, including adding or removing roles of an equal or lower permission level.

Resolves CuBoulder/tiamat10-profile#78

Sister PR in: [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/33)