### PR TITLE
Adds "Google Tag" contrib module

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -66,6 +66,7 @@ install:
   - pantheon_advanced_page_cache
   - simple_sitemap
   - google_cse
+  - google_tag
   - antibot
   - redirect
   - datetime

--- a/config/install/google_tag.container.UA-105731679-1.65de22067902c7.57590325.yml
+++ b/config/install/google_tag.container.UA-105731679-1.65de22067902c7.57590325.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies: {  }
+id: UA-105731679-1.65de22067902c7.57590325
+label: UA-105731679-1
+weight: 0
+tag_container_ids:
+  - UA-105731679-1
+advanced_settings:
+  consent_mode: 1
+dimensions_metrics:
+  -
+    type: ''
+    name: dimension1
+    value: '[node:nid]'
+  -
+    type: dimension
+    name: dimension2
+    value: '[node:title]'
+  -
+    type: dimension
+    name: dimension3
+    value: '[node:content-type]'
+  -
+    type: dimension
+    name: dimension4
+    value: '[node:created]'
+conditions: {  }
+events:
+  generate_lead:
+    value: ''
+    currency: ''
+  search: {  }
+  webform_purchase: {  }
+  custom: {  }
+  login:
+    method: CMS
+  sign_up:
+    method: CMS

--- a/config/install/google_tag.settings.yml
+++ b/config/install/google_tag.settings.yml
@@ -1,0 +1,2 @@
+use_collection: false
+default_google_tag_entity: UA-105731679-1.65de22067902c7.57590325

--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -68,6 +68,7 @@ dependencies:
     - entity_reference_revisions
     - file
     - filter
+    - google_tag
     - layout_builder
     - media
     - node
@@ -108,6 +109,7 @@ permissions:
   - 'administer blocks'
   - 'administer contact forms'
   - 'administer devel_generate'
+  - 'administer google_tag_container'
   - 'administer menu'
   - 'administer news feeds'
   - 'administer redirect settings'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -79,6 +79,7 @@ dependencies:
     - field_ui
     - file
     - filter
+    - google_tag
     - image
     - layout_builder
     - layout_builder_iframe_modal
@@ -157,6 +158,7 @@ permissions:
   - 'administer display modes'
   - 'administer embed buttons'
   - 'administer filters'
+  - 'administer google_tag_container'
   - 'administer image styles'
   - 'administer linkit profiles'
   - 'administer media'


### PR DESCRIPTION
Adds [Google Tag](https://www.drupal.org/project/google_tag) contrib module to serve Google Analytics 4 trackers. The settings were copied over to match D7 Express. Only Architects and Developers can configure Google Tag.

Resolves CuBoulder/tiamat10-profile#90

Sister PR in: [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/35)