### PR TITLE
Change paste filter to accept ckeditor values

### DIFF
--- a/config/install/editor.editor.wysiwyg.yml
+++ b/config/install/editor.editor.wysiwyg.yml
@@ -90,7 +90,7 @@ settings:
           search: '(<[^>]*) (face="[^"]*")'
           replace: $1
         -
-          enabled: true
+          enabled: false
           weight: -7
           search: '(<[^>]*) (class="[^"]*")'
           replace: $1
@@ -110,12 +110,12 @@ settings:
           search: '<\/font>'
           replace: ''
         -
-          enabled: true
+          enabled: false
           weight: -3
           search: '<span[^>]*>'
           replace: ''
         -
-          enabled: true
+          enabled: false
           weight: -2
           search: '<\/span>'
           replace: ''
@@ -135,7 +135,7 @@ settings:
           search: '<b><\/b>'
           replace: ''
         -
-          enabled: true
+          enabled: false
           weight: 2
           search: '<i><\/i>'
           replace: ''


### PR DESCRIPTION
Closes #86.
Removes some of the paste filters to accept ckeditor values. This may have negative consequences on copy-pastes from word and other text editors.