### PR TITLE
Form Configuration

### DIFF
--- a/config/install/webform.settings.yml
+++ b/config/install/webform.settings.yml
@@ -1,0 +1,337 @@
+_core:
+  default_config_hash: Gw_DjU53-aWorpAZwMrBB4BAbND70Lw7A9C0h2mh5Zg
+langcode: en
+settings:
+  default_status: open
+  default_categories: {  }
+  default_page: true
+  default_page_base_path: /form
+  default_ajax: true
+  default_ajax_progress_type: throbber
+  default_ajax_effect: fade
+  default_ajax_speed: 500
+  default_submit_button_label: Submit
+  default_reset_button_label: Reset
+  default_delete_button_label: Delete
+  default_form_submit_once: false
+  default_form_open_message: '<p>This form has not yet been opened to submissions.</p>'
+  default_form_close_message: '<p>Sorry… This form is closed to new submissions.</p>'
+  default_form_exception_message: '<p>Unable to display this webform. Please contact the site administrator.</p>'
+  default_form_confidential_message: '<p>This form is confidential. You must <a href="login-url]/logout?destination=[current-page:url:relative]">Log out</a> to submit it.</p>'
+  default_form_access_denied_message: '<p>Please login to access this form.</p>'
+  default_form_disable_remote_addr: false
+  default_form_novalidate: false
+  default_form_disable_inline_errors: false
+  default_form_required: false
+  default_form_required_label: 'Indicates required field'
+  default_form_unsaved: false
+  default_form_disable_back: false
+  default_form_submit_back: false
+  default_form_details_toggle: true
+  default_form_file_limit: ''
+  default_wizard_prev_button_label: '< Previous'
+  default_wizard_next_button_label: 'Next >'
+  default_wizard_start_label: Start
+  default_wizard_confirmation_label: Complete
+  default_wizard_toggle_show_label: 'Show all'
+  default_wizard_toggle_hide_label: 'Hide all'
+  default_preview_next_button_label: Preview
+  default_preview_prev_button_label: '< Previous'
+  default_preview_label: Preview
+  default_preview_title: '[webform:title]: Preview'
+  default_preview_message: '<p>Please review your submission. Your submission is not complete until you press the "Submit" button!</p>'
+  default_draft_button_label: 'Save Draft'
+  default_draft_saved_message: 'Submission saved. You may return to this form later and it will restore the current values.'
+  default_draft_loaded_message: 'A partially-completed form was found. Please complete the remaining portions.'
+  default_draft_pending_single_message: 'You have a pending draft for this webform. <a href="#">Load your pending draft</a>.'
+  default_draft_pending_multiple_message: 'You have pending drafts for this webform. <a href="#">View your pending drafts</a>.'
+  default_confirmation_message: '<p>New submission added to [webform:title].</p>'
+  default_confirmation_back_label: 'Back to form'
+  default_confirmation_noindex: true
+  default_limit_total_message: 'No more submissions are permitted.'
+  default_limit_user_message: 'No more submissions are permitted.'
+  default_submission_label: '[webform_submission:submitted-to]: Submission #[webform_submission:serial]'
+  default_submission_log: false
+  default_submission_views: {  }
+  default_submission_views_replace:
+    global_routes:
+      - entity.webform_submission.collection
+      - entity.webform_submission.user
+    webform_routes:
+      - entity.webform.results_submissions
+      - entity.webform.user.drafts
+      - entity.webform.user.submissions
+    node_routes:
+      - entity.node.webform.results_submissions
+      - entity.node.webform.user.drafts
+      - entity.node.webform.user.submissions
+  default_results_customize: false
+  default_submission_access_denied_message: 'Please login to access this submission.'
+  default_submission_exception_message: 'Unable to process this submission. Please contact the site administrator.'
+  default_submission_locked_message: 'This submission has been locked.'
+  default_previous_submission_message: 'You have already submitted this webform. <a href="#">View your previous submission</a>.'
+  default_previous_submissions_message: 'You have already submitted this webform. <a href="#">View your previous submissions</a>.'
+  default_autofill_message: 'This submission has been autofilled with your previous submission.'
+  form_classes: |
+    container-inline clearfix
+    form--inline clearfix
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  button_classes: ''
+  preview_classes: |
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  confirmation_classes: |
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  confirmation_back_classes: |
+    button
+  default_share: false
+  default_share_node: false
+  default_share_theme_name: ''
+  webform_bulk_form: true
+  webform_bulk_form_actions:
+    - webform_open_action
+    - webform_close_action
+    - webform_archive_action
+    - webform_unarchive_action
+    - webform_delete_action
+  webform_submission_bulk_form: true
+  webform_submission_bulk_form_actions:
+    - webform_submission_make_sticky_action
+    - webform_submission_make_unsticky_action
+    - webform_submission_make_lock_action
+    - webform_submission_make_unlock_action
+    - webform_submission_delete_action
+  dialog: false
+  dialog_options:
+    narrow:
+      title: Narrow
+      width: 600
+    normal:
+      title: Normal
+      width: 800
+    wide:
+      title: Wide
+      width: 1000
+assets:
+  css: ''
+  javascript: ''
+form:
+  limit: 50
+  filter_category: ''
+  filter_state: ''
+element:
+  machine_name_pattern: a-z0-9_
+  empty_message: '{Empty}'
+  allowed_tags: admin
+  wrapper_classes: |
+    container-inline clearfix
+    form--inline clearfix
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  classes: |
+    container-inline clearfix
+    form--inline clearfix
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  horizontal_rule_classes: |
+    webform-horizontal-rule--solid
+    webform-horizontal-rule--dashed
+    webform-horizontal-rule--dotted
+    webform-horizontal-rule--gradient
+    webform-horizontal-rule--thin
+    webform-horizontal-rule--medium
+    webform-horizontal-rule--thick
+    webform-horizontal-rule--flaired
+    webform-horizontal-rule--glyph
+  default_description_display: ''
+  default_more_title: More
+  default_section_title_tag: h2
+  default_empty_option: true
+  default_empty_option_required: ''
+  default_empty_option_optional: ''
+  excluded_elements:
+    password: password
+    password_confirm: password_confirm
+html_editor:
+  disabled: false
+  element_format: wysiwyg
+  mail_format: wysiwyg
+  tidy: true
+  make_unused_managed_files_temporary: true
+file:
+  file_public: false
+  file_private_redirect: true
+  file_private_redirect_message: 'Please login to access the uploaded file.'
+  default_max_filesize: ''
+  default_managed_file_extensions: 'gif jpg jpeg png bmp eps tif pict psd txt rtf html odf pdf doc docx ppt pptx xls xlsx xml avi mov mp3 mp4 ogg wav bz2 dmg gz jar rar sit svg tar zip'
+  default_image_file_extensions: 'gif jpg jpeg png'
+  default_video_file_extensions: 'avi mov mp4 ogg wav webm'
+  default_audio_file_extensions: 'mp3 ogg wav'
+  default_document_file_extensions: 'txt rtf pdf doc docx odt ppt pptx odp xls xlsx ods'
+  make_unused_managed_files_temporary: true
+  delete_temporary_managed_files: true
+format: {  }
+mail:
+  default_to_mail: '[site:mail]'
+  default_from_mail: '[site:mail]'
+  default_from_name: '[site:name]'
+  default_reply_to: ''
+  default_return_path: ''
+  default_sender_mail: ''
+  default_sender_name: ''
+  default_subject: 'Webform submission from: [webform_submission:source-title]'
+  default_body_text: |
+    Submitted on [webform_submission:created]
+    Submitted by: [webform_submission:user]
+
+    Submitted values are:
+    [webform_submission:values]
+  default_body_html: |
+    <p>Submitted on [webform_submission:created]</p>
+    <p>Submitted by: [webform_submission:user]</p>
+    <p>Submitted values are:</p>
+    [webform_submission:values]
+  roles: {  }
+export:
+  temp_directory: ''
+  exporter: delimited
+  delimiter: ','
+  multiple_delimiter: ;
+  excel: false
+  archive_type: tar
+  header_format: label
+  header_prefix: true
+  header_prefix_key_delimiter: __
+  header_prefix_label_delimiter: ': '
+  entity_reference_items:
+    - id
+    - title
+    - url
+  options_single_format: compact
+  options_multiple_format: compact
+  options_item_format: label
+  likert_answers_format: label
+  signature_format: status
+  composite_element_item_format: label
+  excluded_exporters: {  }
+handler:
+  excluded_handlers: {  }
+variant:
+  excluded_variants: {  }
+batch:
+  default_batch_export_size: 500
+  default_batch_import_size: 100
+  default_batch_update_size: 500
+  default_batch_delete_size: 500
+  default_batch_email_size: 500
+purge:
+  cron_size: 100
+test:
+  types: |
+    checkbox:
+      - true
+    color:
+      - '#ffffcc'
+      - '#ffffcc'
+      - '#ccffff'
+    email:
+      - 'example@example.com'
+      - 'test@test.com'
+      - 'random@random.com'
+    language_select:
+      - en
+    machine_name:
+      - 'loremipsum'
+      - 'oratione'
+      - 'dixisset'
+    tel:
+      - '123-456-7890'
+      - '098-765-4321'
+    textarea:
+      - 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.'
+      - 'Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;'
+      - 'Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.'
+    text_format:
+      - value: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.</p>'
+      - value: '<p>Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;</p>'
+      - value: '<p>Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.</p>'
+    url:
+      - 'http://example.com'
+      - 'http://test.com'
+    webform_email_confirm:
+      - 'example@example.com'
+      - 'test@test.com'
+      - 'random@random.com'
+    webform_email_multiple:
+      - 'example@example.com, test@test.com, random@random.com'
+    webform_time:
+      - '09:00'
+      - '17:00'
+  names: |
+    first_name:
+      - 'John'
+      - 'Paul'
+      - 'Ringo'
+      - 'George'
+    last_name:
+      - 'Lennon'
+      - 'McCartney'
+      - 'Starr'
+      - 'Harrison'
+    address:
+      - '10 Main Street'
+      - '11 Brook Alley Road. APT 1'
+    zip:
+      - '11111'
+      - '12345'
+      - '12345-6789'
+    postal_code:
+      - '11111'
+      - '12345'
+      - '12345-6789'
+    phone:
+      - '123-456-7890'
+      - '098-765-4321'
+    fax:
+      - '123-456-7890'
+      - '098-765-4321'
+    city:
+      - 'Springfield'
+      - 'Pleasantville'
+      - 'Hill Valley'
+    url:
+      - 'http://example.com'
+      - 'http://test.com'
+    default:
+      - 'Loremipsum'
+      - 'Oratione'
+      - 'Dixisset'
+ui:
+  video_display: dialog
+  help_disabled: false
+  dialog_disabled: false
+  offcanvas_disabled: false
+  promotions_disabled: false
+  support_disabled: false
+  details_save: true
+  description_help: true
+  toolbar_item: false
+libraries:
+  excluded_libraries:
+    - choices
+    - jquery.chosen
+requirements:
+  cdn: true
+  clientside_validation: true
+  bootstrap: true
+  spam: true
+third_party_settings:
+  antibot:
+    antibot: false

--- a/config/install/webform.settings.yml
+++ b/config/install/webform.settings.yml
@@ -1,5 +1,5 @@
 _core:
-  default_config_hash: Gw_DjU53-aWorpAZwMrBB4BAbND70Lw7A9C0h2mh5Zg
+  default_config_hash: 0nbc-QwjjjLZljaYJeeEYg3a8d6cKCl11BEiZh9JRIs
 langcode: en
 settings:
   default_status: open
@@ -8,7 +8,7 @@ settings:
   default_page_base_path: /form
   default_ajax: true
   default_ajax_progress_type: throbber
-  default_ajax_effect: fade
+  default_ajax_effect: none
   default_ajax_speed: 500
   default_submit_button_label: Submit
   default_reset_button_label: Reset
@@ -20,9 +20,9 @@ settings:
   default_form_confidential_message: '<p>This form is confidential. You must <a href="login-url]/logout?destination=[current-page:url:relative]">Log out</a> to submit it.</p>'
   default_form_access_denied_message: '<p>Please login to access this form.</p>'
   default_form_disable_remote_addr: false
-  default_form_novalidate: false
+  default_form_novalidate: true
   default_form_disable_inline_errors: false
-  default_form_required: false
+  default_form_required: true
   default_form_required_label: 'Indicates required field'
   default_form_unsaved: false
   default_form_disable_back: false
@@ -334,4 +334,4 @@ requirements:
   spam: true
 third_party_settings:
   antibot:
-    antibot: false
+    antibot: true

--- a/config/install/webform.webform.contact.yml
+++ b/config/install/webform.webform.contact.yml
@@ -1,0 +1,221 @@
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: contact
+title: 'Contact'
+description: '<p>Basic email contact webform.</p>'
+categories: {  }
+elements: |-
+  name:
+    '#type': textfield
+    '#title': 'Your Name'
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  your_email:
+    '#type': email
+    '#title': 'Your Email'
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  subject:
+    '#type': textfield
+    '#title': Subject
+    '#required': true
+    '#test': 'Testing contact webform from [site:name]'
+
+  message:
+    '#type': textarea
+    '#title': Message
+    '#required': true
+    '#test': 'Please ignore this email.'
+
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }


### PR DESCRIPTION
Fixes the following configuration on forms and made config changes requested by Kevin during our Site Accessibility Review:
- Disable client-side validation for all webforms
- Display required indicator on all webforms
- Use Ajax for all webforms by default
- Adds Antibot to all webforms by default

These changes and adding custom profile configuration for the default 'Contact' form allow both single and multipage forms to submit on Form Pages and Blocks

Resolves #110 