### PR TITLE
Adds 'View News Feed' permission to Anonymous Users

### DIFF
--- a/config/install/user.role.anonymous.yml
+++ b/config/install/user.role.anonymous.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - aggregator
     - contact
     - google_cse
     - media
@@ -17,3 +18,4 @@ permissions:
   - 'search Google CSE'
   - 'search content'
   - 'view media'
+  - 'access news feeds'


### PR DESCRIPTION
Adds the needed permission to allow anonymous users to view news feeds on the Aggregator Block. Previously the RSS feed element portion of the block would not display at all for anonymous users, causing image issues as the image part of the block would be the only part rendered.

Resolves #129 