### PR TITLE
Adds `bypass node access` permission to Architect and Content Editor roles

### DIFF
--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -27,8 +27,8 @@ dependencies:
     - block_content.type.video_hero_unit
     - block_content.type.video_reveal
     - core.entity_view_display.node.basic_page.default
-    - filter.format.wysiwyg
     - filter.format.icon_picker
+    - filter.format.wysiwyg
     - media.type.audio
     - media.type.document
     - media.type.image
@@ -119,6 +119,7 @@ permissions:
   - 'administer user invite'
   - 'administer users'
   - 'administer webform element access'
+  - 'bypass node access'
   - 'cancel users by role'
   - 'configure all basic_page node layout overrides'
   - 'configure any layout'

--- a/config/install/user.role.content_editor.yml
+++ b/config/install/user.role.content_editor.yml
@@ -26,8 +26,8 @@ dependencies:
     - block_content.type.ucb_tag_cloud
     - block_content.type.video_reveal
     - core.entity_view_display.node.basic_page.default
-    - filter.format.wysiwyg
     - filter.format.icon_picker
+    - filter.format.wysiwyg
     - media.type.audio
     - media.type.document
     - media.type.image
@@ -92,6 +92,7 @@ permissions:
   - 'administer nodes'
   - 'administer redirect settings'
   - 'administer redirects'
+  - 'bypass node access'
   - 'configure all basic_page node layout overrides'
   - 'configure any layout'
   - 'configure editable basic_page node layout overrides'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -29,8 +29,8 @@ dependencies:
     - block_content.type.video_reveal
     - core.entity_view_display.node.basic_page.default
     - filter.format.full_html
-    - filter.format.wysiwyg
     - filter.format.icon_picker
+    - filter.format.wysiwyg
     - media.type.audio
     - media.type.document
     - media.type.image

--- a/config/install/user.role.edit_own_content.yml
+++ b/config/install/user.role.edit_own_content.yml
@@ -2,8 +2,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.wysiwyg
     - filter.format.icon_picker
+    - filter.format.wysiwyg
     - media.type.audio
     - media.type.document
     - media.type.image


### PR DESCRIPTION
[Change] This update adds a permission which disables access restrictions on unpublished content as well as any other content access restrictions, to the Architect and Content Editor roles. Resolves CuBoulder/tiamat10-profile#112