### PR TITLE
Removing blank password line from smtp configuration

### DIFF
--- a/config/install/smtp.settings.yml
+++ b/config/install/smtp.settings.yml
@@ -6,7 +6,6 @@ smtp_protocol: tls
 smtp_autotls: true
 smtp_timeout: 30
 smtp_username: webexpress_noreply@colorado.edu
-smtp_password: ''
 smtp_from: webexpress_noreply@colorado.edu
 smtp_fromname: 'Web Express'
 smtp_client_hostname: www.colorado.edu


### PR DESCRIPTION
This may cause issues down the line if it attempts to blank out a set password on update.  Removing that line from the config.  