### PR TITLE
Captcha: Adds config and enables on install

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -96,7 +96,9 @@ install:
   - responsive_preview
   - anchor_link
   - simplesamlphp_auth
-  
+  - captcha
+  - recaptcha_v3
+
 # Required modules
 # Note that any dependencies of the modules listed here will be installed automatically.
 dependencies:

--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -1,3 +1,4 @@
+---
 name: CU Boulder Install Profile
 type: profile
 description: "CU Boulder Web Express D10 Installation Profile"
@@ -100,7 +101,8 @@ install:
   - recaptcha_v3
 
 # Required modules
-# Note that any dependencies of the modules listed here will be installed automatically.
+# Note that any dependencies of the modules listed here
+# will be installed automatically.
 dependencies:
   - node
   - block

--- a/config/install/captcha.settings.yml
+++ b/config/install/captcha.settings.yml
@@ -1,5 +1,3 @@
-_core:
-  default_config_hash: UHx-6FUyZIt3WJjbibyVGIvWg0gR3R-6GIbrGYzsaSE
 enable_globally: 0
 enable_globally_on_admin_routes: false
 default_challenge: recaptcha_v3/default

--- a/config/install/captcha.settings.yml
+++ b/config/install/captcha.settings.yml
@@ -1,0 +1,15 @@
+_core:
+  default_config_hash: QDFjOXYIYVwCPQYHY4wAx4DUqOEkNaZokIx6DGApR9I
+enable_globally: 1
+enable_globally_on_admin_routes: false
+default_challenge: recaptcha_v3/default_captcha
+description: 'This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.'
+title: CAPTCHA
+administration_mode: false
+administration_mode_on_admin_routes: false
+whitelist_ips: ''
+wrong_captcha_response_message: 'The answer you entered for the CAPTCHA was not correct.'
+default_validation: 1
+persistence: 1
+enable_stats: false
+log_wrong_responses: false

--- a/config/install/captcha.settings.yml
+++ b/config/install/captcha.settings.yml
@@ -1,12 +1,12 @@
 enable_globally: 0
 enable_globally_on_admin_routes: false
 default_challenge: recaptcha_v3/default
-description: 'This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.'
+description: 'This question is for preventing automated spam submissions.'
 title: CAPTCHA
 administration_mode: false
 administration_mode_on_admin_routes: false
 whitelist_ips: ''
-wrong_captcha_response_message: 'The answer you entered for the CAPTCHA was not correct.'
+wrong_captcha_response_message: 'Incorrect'
 default_validation: 1
 persistence: 1
 enable_stats: false

--- a/config/install/captcha.settings.yml
+++ b/config/install/captcha.settings.yml
@@ -1,3 +1,4 @@
+---
 enable_globally: 0
 enable_globally_on_admin_routes: false
 default_challenge: recaptcha_v3/default

--- a/config/install/captcha.settings.yml
+++ b/config/install/captcha.settings.yml
@@ -1,8 +1,8 @@
 _core:
-  default_config_hash: QDFjOXYIYVwCPQYHY4wAx4DUqOEkNaZokIx6DGApR9I
-enable_globally: 1
+  default_config_hash: UHx-6FUyZIt3WJjbibyVGIvWg0gR3R-6GIbrGYzsaSE
+enable_globally: 0
 enable_globally_on_admin_routes: false
-default_challenge: recaptcha_v3/default_captcha
+default_challenge: recaptcha_v3/default
 description: 'This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.'
 title: CAPTCHA
 administration_mode: false

--- a/config/install/recaptcha_v3.recaptcha_v3_action.default.yml
+++ b/config/install/recaptcha_v3.recaptcha_v3_action.default.yml
@@ -1,4 +1,3 @@
-uuid: 56cb67ba-fe6c-4526-ab82-226f4ce19ba8
 langcode: en
 status: true
 dependencies: {  }

--- a/config/install/recaptcha_v3.recaptcha_v3_action.default.yml
+++ b/config/install/recaptcha_v3.recaptcha_v3_action.default.yml
@@ -1,3 +1,4 @@
+---
 langcode: en
 status: true
 dependencies: {  }

--- a/config/install/recaptcha_v3.recaptcha_v3_action.default.yml
+++ b/config/install/recaptcha_v3.recaptcha_v3_action.default.yml
@@ -1,0 +1,8 @@
+uuid: 56cb67ba-fe6c-4526-ab82-226f4ce19ba8
+langcode: en
+status: true
+dependencies: {  }
+id: default
+label: Default
+threshold: 0.5
+challenge: captcha/Math

--- a/config/install/recaptcha_v3.recaptcha_v3_action.default_captcha.yml
+++ b/config/install/recaptcha_v3.recaptcha_v3_action.default_captcha.yml
@@ -1,8 +1,0 @@
-uuid: 65dce1f3-c34e-45a4-8cc7-bc798571fff9
-langcode: en
-status: true
-dependencies: {  }
-id: default_captcha
-label: 'Default Captcha'
-threshold: 0.5
-challenge: captcha/Math

--- a/config/install/recaptcha_v3.recaptcha_v3_action.default_captcha.yml
+++ b/config/install/recaptcha_v3.recaptcha_v3_action.default_captcha.yml
@@ -1,0 +1,8 @@
+uuid: 65dce1f3-c34e-45a4-8cc7-bc798571fff9
+langcode: en
+status: true
+dependencies: {  }
+id: default_captcha
+label: 'Default Captcha'
+threshold: 0.5
+challenge: captcha/Math

--- a/config/install/recaptcha_v3.settings.yml
+++ b/config/install/recaptcha_v3.settings.yml
@@ -1,6 +1,6 @@
 _core:
-  default_config_hash: ae8AQLsAFXvfcLPmE4YUBcxThAqf7psqRTHzhccslls
-site_key:
+  default_config_hash: 9T0HKuonKLqSmnlUDW7AJNn4j4Yzb4uU1GsbLNwErV8
+site_key: 6LfiWeYpAAAAAKuDrJxtLxXcvS9nvwJfq4s1zbaJ
 secret_key:
 hide_badge: false
 verify_hostname: true

--- a/config/install/recaptcha_v3.settings.yml
+++ b/config/install/recaptcha_v3.settings.yml
@@ -1,3 +1,4 @@
+---
 site_key: 6LfiWeYpAAAAAKuDrJxtLxXcvS9nvwJfq4s1zbaJ
 secret_key:
 hide_badge: false

--- a/config/install/recaptcha_v3.settings.yml
+++ b/config/install/recaptcha_v3.settings.yml
@@ -1,5 +1,5 @@
 ---
-site_key: 6LfiWeYpAAAAAKuDrJxtLxXcvS9nvwJfq4s1zbaJ
+site_key:
 secret_key:
 hide_badge: false
 verify_hostname: true

--- a/config/install/recaptcha_v3.settings.yml
+++ b/config/install/recaptcha_v3.settings.yml
@@ -1,5 +1,3 @@
-_core:
-  default_config_hash: 9T0HKuonKLqSmnlUDW7AJNn4j4Yzb4uU1GsbLNwErV8
 site_key: 6LfiWeYpAAAAAKuDrJxtLxXcvS9nvwJfq4s1zbaJ
 secret_key:
 hide_badge: false

--- a/config/install/recaptcha_v3.settings.yml
+++ b/config/install/recaptcha_v3.settings.yml
@@ -1,0 +1,10 @@
+_core:
+  default_config_hash: ae8AQLsAFXvfcLPmE4YUBcxThAqf7psqRTHzhccslls
+site_key:
+secret_key:
+hide_badge: false
+verify_hostname: true
+default_challenge: captcha/Math
+error_message: 'Antibot verification failed.'
+cacheable: false
+library_use_recaptcha_net: false


### PR DESCRIPTION
Adds config and enables on install for Captcha v3. Needs site keys for v3.

Includes:
- `profile` => https://github.com/CuBoulder/tiamat10-profile/pull/138
- `project-template` => https://github.com/CuBoulder/tiamat10-project-template/pull/45

Resolves https://github.com/CuBoulder/tiamat-theme/issues/617