### PR TITLE
Media Image: Sets Default to use 'Large (1500px, 100% display size)'

### DIFF
--- a/config/install/core.entity_view_display.media.image.default.yml
+++ b/config/install/core.entity_view_display.media.image.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_image_caption
+    - image.style.large_image_style
     - media.type.image
   module:
     - image
@@ -18,7 +19,7 @@ content:
     label: hidden
     settings:
       image_link: ''
-      image_style: ''
+      image_style: large_image_style
       image_loading:
         attribute: lazy
     third_party_settings: {  }


### PR DESCRIPTION
### Media Image
- Sets `Default` to use 'Large (1500px, 100% display size)' Image Style

Resolves https://github.com/CuBoulder/tiamat10-profile/issues/144