### PR TITLE
Social media menu region removal

### DIFF
--- a/config/install/block.block.social_media_links.yml
+++ b/config/install/block.block.social_media_links.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - system.menu.footer_menu
+    - system.menu.social-media-menu
   module:
     - system
   theme:
@@ -12,9 +12,9 @@ theme: boulder_base
 region: footer_menu
 weight: 0
 provider: null
-plugin: 'system_menu_block:footer_menu'
+plugin: 'system_menu_block:social-media-menu'
 settings:
-  id: 'system_menu_block:footer_menu'
+  id: 'system_menu_block:social-media-menu'
   label: 'Social Media Links'
   label_display: '0'
   provider: system

--- a/config/install/block.block.social_media_links.yml
+++ b/config/install/block.block.social_media_links.yml
@@ -2,19 +2,19 @@ langcode: en
 status: true
 dependencies:
   config:
-    - system.menu.social-media-menu
+    - system.menu.footer_menu
   module:
     - system
   theme:
     - boulder_base
 id: social_media_links
 theme: boulder_base
-region: social
+region: footer_menu
 weight: 0
 provider: null
-plugin: 'system_menu_block:social-media-menu'
+plugin: 'system_menu_block:footer_menu'
 settings:
-  id: 'system_menu_block:social-media-menu'
+  id: 'system_menu_block:footer_menu'
   label: 'Social Media Links'
   label_display: '0'
   provider: system

--- a/config/install/system.menu.footer_menu.yml
+++ b/config/install/system.menu.footer_menu.yml
@@ -1,7 +1,0 @@
-langcode: en
-status: true
-dependencies: {  }
-id: footer_menu
-label: 'Footer Menu'
-description: ''
-locked: false

--- a/config/install/system.menu.footer_menu.yml
+++ b/config/install/system.menu.footer_menu.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: footer_menu
+label: 'Footer Menu'
+description: ''
+locked: false


### PR DESCRIPTION
Used in conjunction with https://github.com/CuBoulder/tiamat-theme/pull/1051.
Removes the Social Media Menu Region and moves the Social Media Menu to the Footer Menu.