### PR TITLE
Adds Rebuild Cache Access contrib module

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -99,6 +99,7 @@ install:
   - simplesamlphp_auth
   - captcha
   - recaptcha_v3
+  - rebuild_cache_access
 
 # Required modules
 # Note that any dependencies of the modules listed here

--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -73,6 +73,7 @@ dependencies:
     - node
     - paragraphs
     - path
+    - rebuild_cache_access
     - redirect
     - responsive_preview
     - scheduler
@@ -375,6 +376,7 @@ permissions:
   - 'edit users by role'
   - 'invite users'
   - 'link to any page'
+  - 'rebuild cache access'
   - 'revert all revisions'
   - 'revert any article_list_block block content revisions'
   - 'revert any collection_grid block content revisions'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -89,6 +89,7 @@ dependencies:
     - paragraphs
     - path
     - pathauto
+    - rebuild_cache_access
     - redirect
     - responsive_preview
     - scheduler
@@ -479,6 +480,7 @@ permissions:
   - 'invite users'
   - 'link to any page'
   - 'notify of path changes'
+  - 'rebuild cache access'
   - 'revert all revisions'
   - 'revert any article_list_block block content revisions'
   - 'revert any collection_grid block content revisions'

--- a/config/install/user.role.site_manager.yml
+++ b/config/install/user.role.site_manager.yml
@@ -26,8 +26,8 @@ dependencies:
     - block_content.type.ucb_tag_cloud
     - block_content.type.video_reveal
     - core.entity_view_display.node.basic_page.default
-    - filter.format.wysiwyg
     - filter.format.icon_picker
+    - filter.format.wysiwyg
     - media.type.audio
     - media.type.document
     - media.type.image


### PR DESCRIPTION
This new contrib module adds a "Rebuild Cache" option in the toolbar, accessible to architects and developers. **Use this sparingly and only as a last resort after you've tried everything else, such as clearing local browser caches. A cache rebuild is an administrative action that has temporary negative effects on the performance of the site.**

Resolves CuBoulder/tiamat10-profile#147

Sister PR in: [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/47)