### PR TITLE
Add administer blocks permission to site manager

### DIFF
--- a/config/install/user.role.site_manager.yml
+++ b/config/install/user.role.site_manager.yml
@@ -102,6 +102,7 @@ permissions:
   - 'access user profiles'
   - 'access users overview'
   - 'access webform overview'
+  - 'administer blocks'
   - 'administer contact forms'
   - 'administer menu'
   - 'administer nodes'


### PR DESCRIPTION
Closes https://github.com/CuBoulder/tiamat-theme/issues/1099.
Adds the administer blocks permission, as that is layout manager's only permission to the site manager.