### PR TITLE
Google Tag Update

### DIFF
--- a/config/install/google_tag.container.GTM-M3DX2QP.65de22067902c7.57590325.yml
+++ b/config/install/google_tag.container.GTM-M3DX2QP.65de22067902c7.57590325.yml
@@ -1,13 +1,22 @@
 langcode: en
 status: true
 dependencies: {  }
-id: UA-105731679-1.65de22067902c7.57590325
-label: UA-105731679-1
+id: GTM-M3DX2QP.65de22067902c7.57590325
+label: GTM-M3DX2QP
 weight: 0
 tag_container_ids:
-  - UA-105731679-1
+  - GTM-M3DX2QP
 advanced_settings:
-  consent_mode: 1
+  consent_mode: true
+  gtm:
+    GTM-M3DX2QP:
+      data_layer: dataLayer
+      include_classes: false
+      allowlist_classes: ''
+      blocklist_classes: ''
+      include_environment: false
+      environment_id: ''
+      environment_token: ''
 dimensions_metrics:
   -
     type: ''

--- a/config/install/google_tag.settings.yml
+++ b/config/install/google_tag.settings.yml
@@ -1,2 +1,2 @@
 use_collection: false
-default_google_tag_entity: UA-105731679-1.65de22067902c7.57590325
+default_google_tag_entity: GTM-M3DX2QP.65de22067902c7.57590325


### PR DESCRIPTION
Updaing the google tag manager code from the Universal Analytics to the newer global tag manager code. This is done in the Tag Manager module.
Site users can still put their personal codes in the GTM section of site settings.

Resolve #163 