### PR TITLE
Add menu extras module

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -42,6 +42,7 @@ install:
   - ckeditor5_icons
   - metatag
   - metatag_open_graph
+  - menu_item_extras
   - ucb_ckeditor_plugins
   - webform
   - webform_ui


### PR DESCRIPTION
Closes https://github.com/CuBoulder/tiamat-theme/issues/629.
Adds the ncessary module for the mega menu.