### PR TITLE
New Image Styles: Colorbox Image Styles

### DIFF
--- a/config/install/filter.format.full_html.yml
+++ b/config/install/filter.format.full_html.yml
@@ -2,6 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.colorbox_small
+    - core.entity_view_mode.media.colorbox_small_square
+    - core.entity_view_mode.media.colorbox_small_thumbnail
+    - core.entity_view_mode.media.colorbox_square
     - core.entity_view_mode.media.focal_image_square
     - core.entity_view_mode.media.focal_image_wide
     - core.entity_view_mode.media.large_image_style
@@ -126,6 +130,10 @@ filters:
     settings:
       default_view_mode: media_library
       allowed_view_modes:
+        colorbox_small: colorbox_small
+        colorbox_small_square: colorbox_small_square
+        colorbox_small_thumbnail: colorbox_small_thumbnail
+        colorbox_square: colorbox_square
         focal_image_square: focal_image_square
         focal_image_wide: focal_image_wide
         large_image_style: large_image_style

--- a/config/install/filter.format.wysiwyg.yml
+++ b/config/install/filter.format.wysiwyg.yml
@@ -2,6 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.colorbox_small
+    - core.entity_view_mode.media.colorbox_small_square
+    - core.entity_view_mode.media.colorbox_small_thumbnail
+    - core.entity_view_mode.media.colorbox_square
     - core.entity_view_mode.media.editor_embed_image
     - core.entity_view_mode.media.focal_image_square
     - core.entity_view_mode.media.focal_image_wide
@@ -129,6 +133,10 @@ filters:
       default_view_mode: default
       allowed_view_modes:
         default: default
+        colorbox_small: colorbox_small
+        colorbox_small_square: colorbox_small_square
+        colorbox_small_thumbnail: colorbox_small_thumbnail
+        colorbox_square: colorbox_square
         editor_embed_image: editor_embed_image
         focal_image_square: focal_image_square
         focal_image_wide: focal_image_wide


### PR DESCRIPTION
Adds Colorbox images to editor filters

### New Image Styles
Adds 4 new colorbox image styles: `Colorbox Small` , `Colorbox Small Square`, `Colorbox Small Thumbnail`, `Colorbox Square`. On click, these open up a modal with the full image and caption.

Includes:

- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/1205
- `tiamat-custom-entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/160
- `tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/185

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1174