### PR TITLE
Adds CU Boulder Styled Block custom module and updates block styles

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -78,6 +78,7 @@ install:
   - cu_boulder_content_types
   - ucb_admin_menus
   - ucb_site_configuration
+  - ucb_styled_block
   - ucb_campus_news
   - ucb_user_invite
   - ucb_focal_image_enable


### PR DESCRIPTION
This update:
- [new] Adds the new CU Boulder Styled Block custom module.
- [new] Converts the Campus News block to a styled block, adding new style options to match our other blocks. CuBoulder/ucb_campus_news#6 CuBoulder/ucb_campus_news#9
- [change] Refactors existing styled blocks to all extend the same Twig template with Twig inheritance.
- [change] Corrects some indentation and other minor code style issues in affected block templates.

Sister PR in: [ucb_campus_news](https://github.com/CuBoulder/ucb_campus_news/pull/10), [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/1209), [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/55)