### PR TITLE
Updates Metatag settings

### DIFF
--- a/config/install/metatag.metatag_defaults.404.yml
+++ b/config/install/metatag.metatag_defaults.404.yml
@@ -1,5 +1,5 @@
 langcode: en
-status: true
+status: false
 dependencies: {  }
 id: '404'
 label: '404 page not found'

--- a/config/install/metatag.metatag_defaults.front.yml
+++ b/config/install/metatag.metatag_defaults.front.yml
@@ -1,5 +1,5 @@
 langcode: en
-status: true
+status: false
 dependencies: {  }
 id: front
 label: 'Front page'

--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -5,7 +5,7 @@ id: node
 label: Content
 tags:
   canonical_url: '[node:url]'
-  og_description: '[node:field_ucb_article_content][node:body]'
+  og_description: '[node:field_ucb_article_content][node:summary]'
   og_image: '[node:field_ucb_person_photo:entity:field_media_image:focal_image_square:url][node:field_social_sharing_image:entity:field_media_image:focal_image_square:url][node:field_ucb_article_thumbnail:entity:field_media_image:focal_image_square:url]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'


### PR DESCRIPTION
This update:
- [bug] Fixes meta tags missing on a site's home page but not other pages.
- [change] Resolves description meta tag to summary field instead of body field.

Resolves CuBoulder/tiamat10-profile#189