### PR TITLE
Tag Container Update for Anonymous only tracking

### DIFF
--- a/config/optional/google_tag.container.GTM-M3DX2QP.65de22067902c7.57590325.yml
+++ b/config/optional/google_tag.container.GTM-M3DX2QP.65de22067902c7.57590325.yml
@@ -1,6 +1,10 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - user
+_core:
+  default_config_hash: A71wVnirNKe1Q2SVfZgbc_00mgI8igQS9ziJbGCw9GY
 id: GTM-M3DX2QP.65de22067902c7.57590325
 label: GTM-M3DX2QP
 weight: 0
@@ -34,7 +38,14 @@ dimensions_metrics:
     type: dimension
     name: dimension4
     value: '[node:created]'
-conditions: {  }
+conditions:
+  user_role:
+    id: user_role
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
+    roles:
+      anonymous: anonymous
 events:
   generate_lead:
     value: ''


### PR DESCRIPTION
The change to the optional install file should make it so only anonymous users are being tracked.
This looks to fix the admin control issues too. 
The logged in users now see youtube videos loading properly for video reveal/hero blocks. They are still sometimes broken on anonymous users.