### PR TITLE
Adding in domain masking config

### DIFF
--- a/config/install/pantheon_domain_masking.settings.yml
+++ b/config/install/pantheon_domain_masking.settings.yml
@@ -1,0 +1,4 @@
+_core:
+domain: www.colorado.edu
+enabled: 'no'
+allow_platform: 'no'


### PR DESCRIPTION
Adding in setting for the Pantheon Domain Masking module that are common between all sites and disabling platform access by default when the module is enabled.  