### PR TITLE
Add the date override to taxonomy views

### DIFF
--- a/config/install/views.view.taxonomy_term.yml
+++ b/config/install/views.view.taxonomy_term.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_ucb_article_date_override
     - field.storage.node.field_ucb_article_summary
     - field.storage.node.field_ucb_article_thumbnail
     - field.storage.paragraph.field_article_text
@@ -9,6 +10,7 @@ dependencies:
   module:
     - media
     - node
+    - options
     - paragraphs
     - taxonomy
     - text
@@ -349,6 +351,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        field_ucb_article_date_override:
+          id: field_ucb_article_date_override
+          table: node__field_ucb_article_date_override
+          field: field_ucb_article_date_override
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_key
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         title:
           id: title
           table: node_field_data
@@ -363,7 +427,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "{% if field_ucb_article_thumbnail %}\r\n<div class = \"ucb-taxonomy-thumbnail\">{{ field_ucb_article_thumbnail }}</div>\r\n{% endif %}\r\n<div class = \"ucb-view-wrapper\">\r\n<div class = \"ucb-taxonomy-title\"> {{ title }} </div>\r\n<div class = \"ucb-taxonomy-date\"> {{ created }} </div>\r\n<div class= \"ucb-taxonomy-summary\">\r\n{% if field_ucb_article_summary %}\r\n{{ field_ucb_article_summary }}\r\n{% else %}\r\n{{ field_article_text }}\r\n{% endif %}\r\n</div>\r\n<div class= \"ucb-taxonomy-readmore\">{{ view_node }} </div>\r\n</div>"
+            text: "{% if field_ucb_article_thumbnail %}\r\n<div class = \"ucb-taxonomy-thumbnail\">{{ field_ucb_article_thumbnail }}</div>\r\n{% endif %}\r\n<div class = \"ucb-view-wrapper\">\r\n<div class = \"ucb-taxonomy-title\"> {{ title }} </div>\r\n{% if field_ucb_article_date_override|render|striptags|trim != 7 %}\r\n<div class = \"ucb-taxonomy-date\"> {{ created }} </div>\r\n{% endif %}\r\n<div class= \"ucb-taxonomy-summary\">\r\n{% if field_ucb_article_summary %}\r\n{{ field_ucb_article_summary }}\r\n{% else %}\r\n{{ field_article_text }}\r\n{% endif %}\r\n</div>\r\n<div class= \"ucb-taxonomy-readmore\">{{ view_node }} </div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -708,6 +772,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_ucb_article_date_override'
         - 'config:field.storage.node.field_ucb_article_summary'
         - 'config:field.storage.node.field_ucb_article_thumbnail'
         - 'config:field.storage.paragraph.field_article_text'
@@ -750,6 +815,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_ucb_article_date_override'
         - 'config:field.storage.node.field_ucb_article_summary'
         - 'config:field.storage.node.field_ucb_article_thumbnail'
         - 'config:field.storage.paragraph.field_article_text'
@@ -786,6 +852,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_ucb_article_date_override'
         - 'config:field.storage.node.field_ucb_article_summary'
         - 'config:field.storage.node.field_ucb_article_thumbnail'
         - 'config:field.storage.paragraph.field_article_text'

--- a/config/install/views.view.taxonomy_term.yml
+++ b/config/install/views.view.taxonomy_term.yml
@@ -427,7 +427,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "{% if field_ucb_article_thumbnail %}\r\n<div class = \"ucb-taxonomy-thumbnail\">{{ field_ucb_article_thumbnail }}</div>\r\n{% endif %}\r\n<div class = \"ucb-view-wrapper\">\r\n<div class = \"ucb-taxonomy-title\"> {{ title }} </div>\r\n{% if field_ucb_article_date_override|render|striptags|trim != 7 %}\r\n<div class = \"ucb-taxonomy-date\"> {{ created }} </div>\r\n{% endif %}\r\n<div class= \"ucb-taxonomy-summary\">\r\n{% if field_ucb_article_summary %}\r\n{{ field_ucb_article_summary }}\r\n{% else %}\r\n{{ field_article_text }}\r\n{% endif %}\r\n</div>\r\n<div class= \"ucb-taxonomy-readmore\">{{ view_node }} </div>\r\n</div>"
+            text: "{% if field_ucb_article_thumbnail %}\r\n<div class = \"ucb-taxonomy-thumbnail\">{{ field_ucb_article_thumbnail }}</div>\r\n{% endif %}\r\n<div class = \"ucb-view-wrapper\">\r\n<div class = \"ucb-taxonomy-title\"> {{ title }} </div>\r\n{% set global_date_format = drupal_config('ucb_site_configuration.settings', 'article_date_format') %}\r\n{% set node_date_override = field_ucb_article_date_override|render|striptags|trim %}\r\n\r\n{% if node_date_override != '7' and (global_date_format != 6 or node_date_override != '0') %}\r\n  <div class=\"ucb-taxonomy-date\"> {{ created }} </div>\r\n{% endif %}\r\n<div class= \"ucb-taxonomy-summary\">\r\n{% if field_ucb_article_summary %}\r\n{{ field_ucb_article_summary }}\r\n{% else %}\r\n{{ field_article_text }}\r\n{% endif %}\r\n</div>\r\n<div class= \"ucb-taxonomy-readmore\">{{ view_node }} </div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false


### PR DESCRIPTION
Helps resolve https://github.com/CuBoulder/tiamat-theme/issues/1429.
Adds the article override to the taxonomy term page.
Theme -> https://github.com/CuBoulder/tiamat-theme/pull/1470.