### PR TITLE
#235 Allows Webform Submission viewer to navigate to Submissions

### DIFF
--- a/config/install/user.role.webform_submissions_viewer.yml
+++ b/config/install/user.role.webform_submissions_viewer.yml
@@ -2,11 +2,17 @@ langcode: en
 status: true
 dependencies:
   module:
+    - system
+    - toolbar
     - webform
 id: webform_submissions_viewer
 label: 'Webform Submissions Viewer'
 weight: 12
 is_admin: null
 permissions:
+  - 'access administration pages'
+  - 'access toolbar'
+  - 'access webform overview'
   - 'view any webform submission'
   - 'view own webform submission'
+  - 'view the administration theme'


### PR DESCRIPTION
Gives the "Webform Submissions Viewer" Role the ability to navigate to the Submissions page via the toolbar. Previously this was only possible via direct link, but this adds the following permissions to allow that route of navigation:

  - 'access administration pages'
  - 'access toolbar'
  - 'access webform overview'
  - 'view the administration theme'

Webforms will be the only link that shows up in their Toolbar under Structure

Resolves https://github.com/CuBoulder/tiamat10-profile/issues/235

