### PR TITLE
#244 Site Managers: sitemap permissions to exclude content

### DIFF
--- a/config/install/user.role.site_manager.yml
+++ b/config/install/user.role.site_manager.yml
@@ -79,6 +79,7 @@ dependencies:
     - scheduler
     - search
     - shortcut
+    - simple_sitemap
     - system
     - taxonomy
     - toolbar
@@ -335,6 +336,7 @@ permissions:
   - 'edit any video media'
   - 'edit any video_reveal block content'
   - 'edit any webform'
+  - 'edit entity sitemap settings'
   - 'edit own audio media'
   - 'edit own basic_page content'
   - 'edit own collection_item_page content'


### PR DESCRIPTION
Gives 'Site Managers' the ability to exclude content from the sitemap

Resolves https://github.com/CuBoulder/tiamat10-profile/issues/244