### PR TITLE
Webforms: Modify config to defauts to prevent multiple submissions

### DIFF
--- a/boulder_profile.install
+++ b/boulder_profile.install
@@ -143,3 +143,15 @@ function _boulder_profile_install_webform_settings() {
   $htmlEditorSettings['element_format'] = $htmlEditorSettings['mail_format'] = 'wysiwyg';
   $settings->set('html_editor', $htmlEditorSettings)->save();
 }
+
+/**
+ * Updates Webform settings by importing new configuration and applying custom settings.
+ * We reset the config after finding stray JS that breaks forms
+ */
+function boulder_profile_update_9503() {
+  // Re-import the Webform settings from the updated configuration.
+  \Drupal::configFactory()->getEditable('webform.settings')->save();
+
+  // Apply additional Webform settings modifications.
+  _boulder_profile_install_webform_settings();
+}

--- a/boulder_profile.install
+++ b/boulder_profile.install
@@ -143,15 +143,3 @@ function _boulder_profile_install_webform_settings() {
   $htmlEditorSettings['element_format'] = $htmlEditorSettings['mail_format'] = 'wysiwyg';
   $settings->set('html_editor', $htmlEditorSettings)->save();
 }
-
-/**
- * Updates Webform settings by importing new configuration and applying custom settings.
- * We reset the config after finding stray JS that breaks forms
- */
-function boulder_profile_update_9503() {
-  // Re-import the Webform settings from the updated configuration.
-  \Drupal::configFactory()->getEditable('webform.settings')->save();
-
-  // Apply additional Webform settings modifications.
-  _boulder_profile_install_webform_settings();
-}

--- a/config/install/webform.settings.yml
+++ b/config/install/webform.settings.yml
@@ -1,14 +1,12 @@
-_core:
-  default_config_hash: 0nbc-QwjjjLZljaYJeeEYg3a8d6cKCl11BEiZh9JRIs
 langcode: en
 settings:
   default_status: open
   default_categories: {  }
   default_page: true
   default_page_base_path: /form
-  default_ajax: true
+  default_ajax: false
   default_ajax_progress_type: throbber
-  default_ajax_effect: none
+  default_ajax_effect: fade
   default_ajax_speed: 500
   default_submit_button_label: Submit
   default_reset_button_label: Reset
@@ -19,8 +17,7 @@ settings:
   default_form_exception_message: '<p>Unable to display this webform. Please contact the site administrator.</p>'
   default_form_confidential_message: '<p>This form is confidential. You must <a href="login-url]/logout?destination=[current-page:url:relative]">Log out</a> to submit it.</p>'
   default_form_access_denied_message: '<p>Please login to access this form.</p>'
-  default_form_disable_remote_addr: false
-  default_form_novalidate: true
+  default_form_novalidate: false
   default_form_disable_inline_errors: false
   default_form_required: true
   default_form_required_label: 'Indicates required field'


### PR DESCRIPTION
This update turns off Ajax and resets the form config back to mostly default, so that forms aren't submitted multiple times. We are currently working on debugging multi-page form blocks which seem to have the most issues. Strongly recommended to try to keep new Webforms limited to Webform Pages or modify existing Form blocks to pages, especially the more complex multi-page forms until more is known about the issue. 

With this disabled you should also be able to enable Ajax as a per-form setting, which may help issues with complex multi-page forms. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1330
Resolves https://github.com/CuBoulder/tiamat10-profile/issues/215