### PR TITLE
Add Klaro (GDPR) Cookie manager

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -72,6 +72,7 @@ install:
   - simple_sitemap
   - google_cse
   - google_tag
+  - klaro
   - antibot
   - smtp
   - redirect

--- a/config/install/klaro.klaro_app.facebook.yml
+++ b/config/install/klaro.klaro_app.facebook.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies: {  }
+id: facebook
+label: Facebook
+description: 'Facebook is a social media platform by Meta Platforms, Inc (USA).'
+default: true
+purposes:
+  - external_content
+cookies: {  }
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: false
+contextual_consent_text: ''
+info_url: 'https://about.meta.com/company-info'
+privacy_policy_url: 'https://www.facebook.com/privacy/policy/'
+javascripts:
+  - www.facebook.com
+callback_code: ''
+wrapper_identifier: {  }
+attachments: {  }
+weight: 0

--- a/config/install/klaro.klaro_app.ga.yml
+++ b/config/install/klaro.klaro_app.ga.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies: {  }
+id: ga
+label: 'Google Analytics'
+description: 'Tracks online visits of the website as a service.'
+default: true
+purposes:
+  - analytics
+cookies:
+  -
+    regex: '^_ga(_.*)?'
+    path: ''
+    domain: ''
+  -
+    regex: ^_gid
+    path: ''
+    domain: ''
+  -
+    regex: ^IDE
+    path: ''
+    domain: ''
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: false
+contextual_consent_text: ''
+info_url: 'https://marketingplatform.google.com/intl/de/about/analytics/'
+privacy_policy_url: 'https://policies.google.com/privacy'
+javascripts:
+  - analytics.js
+callback_code: ''
+wrapper_identifier: {  }
+attachments:
+  - ga4_google_analytics
+weight: 1

--- a/config/install/klaro.klaro_app.gtm.yml
+++ b/config/install/klaro.klaro_app.gtm.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies: {  }
+id: gtm
+label: 'Google Tag Manager'
+description: 'Manages and deploys marketing tags.'
+default: true
+purposes:
+  - advertising
+cookies: {  }
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: false
+contextual_consent_text: ''
+info_url: 'https://marketingplatform.google.com/intl/de/about/tag-manager/'
+privacy_policy_url: 'https://policies.google.com/privacy'
+javascripts:
+  - gtm.js
+  - gtag.js
+  - 'https://www.googletagmanager.com/ns.html'
+callback_code: ''
+wrapper_identifier: {  }
+attachments:
+  - gtm
+weight: 2

--- a/config/install/klaro.klaro_app.tiktok.yml
+++ b/config/install/klaro.klaro_app.tiktok.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies: {  }
+id: tiktok
+label: TikTok
+description: 'TikTok is a social media platform by Bytedance Ltd. (China/Cayman Islands).'
+default: true
+purposes:
+  - external_content
+cookies: {  }
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: false
+contextual_consent_text: ''
+info_url: 'https://www.tiktok.com/about'
+privacy_policy_url: 'https://www.tiktok.com/legal/privacy-policy-row'
+javascripts:
+  - www.tiktok.com
+callback_code: ''
+wrapper_identifier:
+  - .tiktok-embed
+attachments: {  }
+weight: 0

--- a/config/install/klaro.klaro_app.vimeo.yml
+++ b/config/install/klaro.klaro_app.vimeo.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies: {  }
+id: vimeo
+label: Vimeo
+description: 'Vimeo is a video sharing platform by Vimeo, LLC (USA).'
+default: true
+purposes:
+  - external_content
+cookies: {  }
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: false
+contextual_consent_text: ''
+info_url: 'https://vimeo.com/'
+privacy_policy_url: 'https://vimeo.com/privacy'
+javascripts:
+  - vimeo.com
+callback_code: ''
+wrapper_identifier: {  }
+attachments: {  }
+weight: 0

--- a/config/install/klaro.klaro_app.youtube.yml
+++ b/config/install/klaro.klaro_app.youtube.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies: {  }
+id: youtube
+label: YouTube
+description: 'YouTube is an online video sharing platform owned by Google.'
+default: true
+purposes:
+  - external_content
+cookies: {  }
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: false
+contextual_consent_text: ''
+info_url: 'https://www.youtube.com/'
+privacy_policy_url: 'https://www.youtube.com/howyoutubeworks/our-commitments/protecting-user-data/'
+javascripts:
+  - youtube.com
+  - youtu.be
+  - youtube-nocookie.com
+  - ytimg.com
+callback_code: ''
+wrapper_identifier: {  }
+attachments: {  }
+weight: 0

--- a/config/install/klaro.settings.yml
+++ b/config/install/klaro.settings.yml
@@ -1,0 +1,35 @@
+langcode: en
+dialog_mode: notice
+auto_decorate_final_html: false
+auto_decorate_js_alter: true
+auto_decorate_page_attachments: true
+auto_decorate_preprocess_field: true
+get_entity_thumbnail: true
+block_unknown: false
+log_unknown_resources: false
+block_unknown_label: 'Unknown services'
+block_unknown_description: 'Allow loading of unknown external resources'
+show_toggle_button: false
+show_close_button: true
+deletable_cookie_domains:
+  - colorado.edu
+exclude_urls: {  }
+disable_urls: {  }
+styles:
+  - light
+process_descriptions: false
+override_css: true
+library:
+  element_id: klaro
+  storage_method: cookie
+  cookie_name: klaro
+  cookie_expires_after_days: 180
+  cookie_domain: colorado.edu
+  group_by_purpose: false
+  accept_all: true
+  hide_decline_all: false
+  hide_learn_more: false
+  learn_more_as_button: false
+  additional_class: ucb-klaro-styles
+  html_texts: false
+  auto_focus: true

--- a/config/install/klaro.texts.yml
+++ b/config/install/klaro.texts.yml
@@ -1,0 +1,35 @@
+langcode: en
+consentModal:
+  title: 'Use of personal data and cookies'
+  description: "Please choose the services and 3rd party applications we would like to use.\r\n"
+  privacyPolicy:
+    name: 'privacy policy'
+    text: "To learn more, please read our {privacyPolicy}.\r\n"
+    url: 'https://www.colorado.edu/compliance/policies/privacy-statement'
+consentNotice:
+  changeDescription: 'There were changes since your last visit, please update your consent.'
+  description: "We use cookies and process personal data for the following purposes: {purposes}.\r\n"
+  learnMore: Customize
+ok: Accept
+save: Save
+decline: Decline
+close: Close
+acceptAll: 'Accept all'
+acceptSelected: 'Accept selected'
+service:
+  disableAll:
+    title: 'Toggle all services'
+    description: 'Use this switch to enable/disable all services.'
+  optOut:
+    title: (opt-out)
+    description: 'This service is loaded by default (opt-out possible).'
+  required:
+    title: '(always required)'
+    description: 'This service is always required.'
+  purposes: Purposes
+  purpose: Purpose
+contextualConsent:
+  acceptAlways: Always
+  acceptOnce: 'Yes (this time)'
+  description: 'Load external content supplied by {title}?'
+poweredBy: 'Powered by Klaro!'

--- a/config/install/user.role.anonymous.yml
+++ b/config/install/user.role.anonymous.yml
@@ -5,6 +5,7 @@ dependencies:
     - aggregator
     - contact
     - google_cse
+    - klaro
     - media
     - search
     - system
@@ -18,4 +19,5 @@ permissions:
   - 'access site-wide contact form'
   - 'search Google CSE'
   - 'search content'
+  - 'use klaro'
   - 'view media'

--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -72,6 +72,7 @@ dependencies:
     - filter
     - google_tag
     - help
+    - klaro
     - layout_builder
     - media
     - node
@@ -118,6 +119,7 @@ permissions:
   - 'administer blocks'
   - 'administer contact forms'
   - 'administer google_tag_container'
+  - 'administer klaro'
   - 'administer menu'
   - 'administer news feeds'
   - 'administer nodes'

--- a/config/install/user.role.authenticated.yml
+++ b/config/install/user.role.authenticated.yml
@@ -5,6 +5,7 @@ dependencies:
     - aggregator
     - contact
     - google_cse
+    - klaro
     - media
     - search
     - system
@@ -20,4 +21,5 @@ permissions:
   - 'access webform submission user'
   - 'search Google CSE'
   - 'search content'
+  - 'use klaro'
   - 'view media'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -83,6 +83,7 @@ dependencies:
     - google_tag
     - help
     - image
+    - klaro
     - layout_builder
     - layout_builder_iframe_modal
     - linkit
@@ -167,6 +168,7 @@ permissions:
   - 'administer filters'
   - 'administer google_tag_container'
   - 'administer image styles'
+  - 'administer klaro'
   - 'administer linkit profiles'
   - 'administer media'
   - 'administer media display'


### PR DESCRIPTION
Profile and installation settings for the new Klaro! module. 

Devs and Architects have access to the settings options for Klaro
anonymous and authenticated users all needed permissions to interact with the popup.

By default klaro is looking for 
 - gtm
 - ga
 - facebook
 - tiktok
 - youtube
 - vimeo

Sister PR: https://github.com/CuBoulder/tiamat-theme/pull/1607
Sister PR: https://github.com/CuBoulder/tiamat10-project-template/pull/75