### PR TITLE
Removing Klaro from the base install

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -72,7 +72,7 @@ install:
   - simple_sitemap
   - google_cse
   - google_tag
-  - klaro
+  #- klaro
   - antibot
   - smtp
   - redirect

--- a/config/install/user.role.anonymous.yml
+++ b/config/install/user.role.anonymous.yml
@@ -5,7 +5,6 @@ dependencies:
     - aggregator
     - contact
     - google_cse
-    - klaro
     - media
     - search
     - system
@@ -19,5 +18,4 @@ permissions:
   - 'access site-wide contact form'
   - 'search Google CSE'
   - 'search content'
-  - 'use klaro'
   - 'view media'

--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -72,7 +72,6 @@ dependencies:
     - filter
     - google_tag
     - help
-    - klaro
     - layout_builder
     - media
     - node
@@ -119,7 +118,6 @@ permissions:
   - 'administer blocks'
   - 'administer contact forms'
   - 'administer google_tag_container'
-  - 'administer klaro'
   - 'administer menu'
   - 'administer news feeds'
   - 'administer nodes'

--- a/config/install/user.role.authenticated.yml
+++ b/config/install/user.role.authenticated.yml
@@ -5,7 +5,6 @@ dependencies:
     - aggregator
     - contact
     - google_cse
-    - klaro
     - media
     - search
     - system
@@ -21,5 +20,4 @@ permissions:
   - 'access webform submission user'
   - 'search Google CSE'
   - 'search content'
-  - 'use klaro'
   - 'view media'

--- a/config/install/user.role.developer.yml
+++ b/config/install/user.role.developer.yml
@@ -83,7 +83,6 @@ dependencies:
     - google_tag
     - help
     - image
-    - klaro
     - layout_builder
     - layout_builder_iframe_modal
     - linkit
@@ -168,7 +167,6 @@ permissions:
   - 'administer filters'
   - 'administer google_tag_container'
   - 'administer image styles'
-  - 'administer klaro'
   - 'administer linkit profiles'
   - 'administer media'
   - 'administer media display'

--- a/config/optional/klaro.klaro_app.facebook.yml
+++ b/config/optional/klaro.klaro_app.facebook.yml
@@ -1,6 +1,8 @@
 langcode: en
+dependencies: 
+  module: 
+    - klaro
 status: true
-dependencies: {  }
 id: facebook
 label: Facebook
 description: 'Facebook is a social media platform by Meta Platforms, Inc (USA).'

--- a/config/optional/klaro.klaro_app.ga.yml
+++ b/config/optional/klaro.klaro_app.ga.yml
@@ -1,6 +1,8 @@
 langcode: en
+dependencies: 
+  module: 
+    - klaro
 status: true
-dependencies: {  }
 id: ga
 label: 'Google Analytics'
 description: 'Tracks online visits of the website as a service.'

--- a/config/optional/klaro.klaro_app.gtm.yml
+++ b/config/optional/klaro.klaro_app.gtm.yml
@@ -1,6 +1,8 @@
 langcode: en
+dependencies: 
+  module: 
+    - klaro
 status: true
-dependencies: {  }
 id: gtm
 label: 'Google Tag Manager'
 description: 'Manages and deploys marketing tags.'

--- a/config/optional/klaro.klaro_app.tiktok.yml
+++ b/config/optional/klaro.klaro_app.tiktok.yml
@@ -1,6 +1,8 @@
 langcode: en
+dependencies: 
+  module: 
+    - klaro
 status: true
-dependencies: {  }
 id: tiktok
 label: TikTok
 description: 'TikTok is a social media platform by Bytedance Ltd. (China/Cayman Islands).'

--- a/config/optional/klaro.klaro_app.vimeo.yml
+++ b/config/optional/klaro.klaro_app.vimeo.yml
@@ -1,6 +1,8 @@
 langcode: en
+dependencies: 
+  module: 
+    - klaro
 status: true
-dependencies: {  }
 id: vimeo
 label: Vimeo
 description: 'Vimeo is a video sharing platform by Vimeo, LLC (USA).'

--- a/config/optional/klaro.klaro_app.youtube.yml
+++ b/config/optional/klaro.klaro_app.youtube.yml
@@ -1,6 +1,8 @@
 langcode: en
+dependencies: 
+  module: 
+    - klaro
 status: true
-dependencies: {  }
 id: youtube
 label: YouTube
 description: 'YouTube is an online video sharing platform owned by Google.'

--- a/config/optional/klaro.settings.yml
+++ b/config/optional/klaro.settings.yml
@@ -1,4 +1,7 @@
 langcode: en
+dependencies: 
+  module: 
+    - klaro
 dialog_mode: notice
 auto_decorate_final_html: false
 auto_decorate_js_alter: true

--- a/config/optional/klaro.texts.yml
+++ b/config/optional/klaro.texts.yml
@@ -1,4 +1,7 @@
 langcode: en
+dependencies: 
+  module: 
+    - klaro
 consentModal:
   title: 'Use of personal data and cookies'
   description: "Please choose the services and 3rd party applications we would like to use.\r\n"


### PR DESCRIPTION
Klaro is in testing on the Sandbox sites but should not be enable in production.  Moving the config for that module from `config/install` to `config/optional` and setting a module dependency so that this config will be added once the module is turned on.  