### PR TITLE
Update metatag.metatag_defaults.node.yml

### DIFF
--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -5,7 +5,7 @@ id: node
 label: Content
 tags:
   canonical_url: '[node:url]'
-  og_description: '[node:field_ucb_article_content][node:summary]'
+  og_description: '[node:field_ucb_article_content][node:summary][node:body:summary][node:field_summary]'
   og_image: '[node:field_ucb_person_photo:entity:field_media_image:focal_image_square:url][node:field_social_sharing_image:entity:field_media_image:focal_image_square:url][node:field_ucb_article_thumbnail:entity:field_media_image:focal_image_square:url]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'


### PR DESCRIPTION
Add in `[node:body:summary]` and `[node:field_summary]` to the summary grab checks for description meta information.

Resolves #277