### PR TITLE
#279 - Using direct image file paths instead of image styles pathing for `og:image` previews

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -43,6 +43,7 @@ install:
   - ckeditor5_icons
   - metatag
   - metatag_open_graph
+  - metatag_twitter_cards
   - menu_item_extras
   - ucb_ckeditor_plugins
   - webform

--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -4,9 +4,10 @@ dependencies: {  }
 id: node
 label: Content
 tags:
+  twitter_cards_type: summary_large_image
   canonical_url: '[node:url]'
   og_description: '[node:field_ucb_article_content][node:summary]'
-  og_image: '[node:field_ucb_person_photo:entity:field_media_image:file-url][node:field_social_sharing_image:entity:field_media_image:file-url][node:field_ucb_article_thumbnail:entity:field_media_image:file-url]'
+  og_image: '[node:field_ucb_person_photo:entity:field_media_image:entity:url],[node:field_social_sharing_image:entity:field_media_image:entity:url],[node:field_ucb_article_thumbnail:entity:field_media_image:entity:url]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'
   title: '[node:title] | [site:name]'

--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -6,7 +6,7 @@ label: Content
 tags:
   twitter_cards_type: summary_large_image
   canonical_url: '[node:url]'
-  og_description: '[node:field_ucb_article_summary],[node:summary],[node:body:summary],[node:field_summary]'
+  og_description: '[node:field_ucb_article_summary][node:summary][node:body:summary][node:field_summary]'
   og_image: '[node:field_ucb_person_photo:entity:field_media_image:entity:url],[node:field_social_sharing_image:entity:field_media_image:entity:url],[node:field_ucb_article_thumbnail:entity:field_media_image:entity:url]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'

--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -6,7 +6,7 @@ label: Content
 tags:
   canonical_url: '[node:url]'
   og_description: '[node:field_ucb_article_content][node:summary]'
-  og_image: '[node:field_ucb_person_photo:entity:field_media_image:focal_image_square:url][node:field_social_sharing_image:entity:field_media_image:focal_image_square:url][node:field_ucb_article_thumbnail:entity:field_media_image:focal_image_square:url]'
+  og_image: '[node:field_ucb_person_photo:entity:field_media_image:file-url][node:field_social_sharing_image:entity:field_media_image:file-url][node:field_ucb_article_thumbnail:entity:field_media_image:file-url]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'
   title: '[node:title] | [site:name]'

--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -6,7 +6,7 @@ label: Content
 tags:
   twitter_cards_type: summary_large_image
   canonical_url: '[node:url]'
-  og_description: '[node:field_ucb_article_content][node:summary]'
+  og_description: '[node:field_ucb_article_summary],[node:summary],[node:body:summary],[node:field_summary]'
   og_image: '[node:field_ucb_person_photo:entity:field_media_image:entity:url],[node:field_social_sharing_image:entity:field_media_image:entity:url],[node:field_ucb_article_thumbnail:entity:field_media_image:entity:url]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'


### PR DESCRIPTION
Previously images in Cards/Previews when sharing a site via Facebook, Twitter, Teams, etc. would not show up, despite having correct Open Graph tags. This is believed to be caused by additional url information added to the end of links, which has been adjusted to just grab the image, rather than a processed version with additional info

Includes: 
- `profile` => https://github.com/CuBoulder/tiamat10-profile/pull/280
- `custom_entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/210

Resolves #279
Resolves #277 