### PR TITLE
Update boulder_profile.info.yml

### DIFF
--- a/boulder_profile.info.yml
+++ b/boulder_profile.info.yml
@@ -52,6 +52,7 @@ install:
   - admin_toolbar_tools
   - media
   - media_library
+  - media_library_form_element
   - field_group
   - twig_tweak
   - telephone


### PR DESCRIPTION
Update to add back in `media_library_form_element` so that background images work for the sections forms as well as other image errors.

Resolves #316 