### PR TITLE
#1821 - Fixes issue with captions not displaying on Focal Image Wide/Square image styles

### DIFF
--- a/config/install/core.entity_view_display.media.image.focal_image_square.yml
+++ b/config/install/core.entity_view_display.media.image.focal_image_square.yml
@@ -10,6 +10,7 @@ dependencies:
   module:
     - image
     - layout_builder
+    - text
 third_party_settings:
   layout_builder:
     enabled: false
@@ -30,9 +31,15 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  field_media_image_caption:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   created: true
-  field_media_image_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/config/install/core.entity_view_display.media.image.focal_image_wide.yml
+++ b/config/install/core.entity_view_display.media.image.focal_image_wide.yml
@@ -10,6 +10,7 @@ dependencies:
   module:
     - image
     - layout_builder
+    - text
 third_party_settings:
   layout_builder:
     enabled: false
@@ -30,9 +31,15 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  field_media_image_caption:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   created: true
-  field_media_image_caption: true
   name: true
   thumbnail: true
   uid: true


### PR DESCRIPTION
Previously the 'Focal Image Wide' and 'Focal Image Square' image styles did not display Captions set on the media. This has been corrected for those two Image Styles

Includes:
- `custom_entities` =>  https://github.com/CuBoulder/tiamat-custom-entities/pull/235
- `profile` => https://github.com/CuBoulder/tiamat10-profile/pull/328

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1821