### PR TITLE
Enable metatag defaults

### DIFF
--- a/boulder_profile.install
+++ b/boulder_profile.install
@@ -62,6 +62,16 @@ function boulder_profile_update_9503() {
 }
 
 /**
+ * Enables the front page Metatag defaults for correct homepage canonical URLs.
+ */
+function boulder_profile_update_9504() {
+  \Drupal::configFactory()
+    ->getEditable('metatag.metatag_defaults.front')
+    ->set('status', TRUE)
+    ->save();
+}
+
+/**
  * Installs default (privileged) users.
  */
 function _boulder_profile_install_users() {

--- a/config/install/metatag.metatag_defaults.front.yml
+++ b/config/install/metatag.metatag_defaults.front.yml
@@ -1,5 +1,5 @@
 langcode: en
-status: false
+status: true
 dependencies: {  }
 id: front
 label: 'Front page'


### PR DESCRIPTION
Change metatag default to true to handle [site:url] as the main canonical name scheme for SEO

Resolves #334