### PR TITLE
Updates for Drupal 11.4

### DIFF
--- a/boulder_profile.install
+++ b/boulder_profile.install
@@ -17,11 +17,7 @@ use Symfony\Component\Yaml\Yaml;
  * @see system_install()
  */
 function boulder_profile_install() {
-  // First, do everything in standard profile.
-  include_once DRUPAL_ROOT . '/core/profiles/standard/standard.install';
-  standard_install();
-
-  // Afterward, run the custom install tasks.
+  // Run the custom install tasks.
   _boulder_profile_install_users();
   _boulder_profile_install_shortcuts();
   _boulder_profile_install_administerusersbyrole_settings();

--- a/config/install/trash.settings.yml
+++ b/config/install/trash.settings.yml
@@ -1,5 +1,5 @@
-enabled_entity_types:
-  node: {  }
+enabled_entity_types: {  }
 auto_purge:
   enabled: false
   after: '30 days'
+compact_overview: false


### PR DESCRIPTION
Remove install references to the core profile standard install to remove references to deprecated code that was removed in Drupal 11.4. 